### PR TITLE
feat: 新增 Groq 雲端語音辨識、Fn 鍵支援、可配置熱鍵與觸發模式

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1803,6 +1814,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2133,10 +2160,11 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open-flow"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "arboard",
+ "async-trait",
  "clap",
  "cocoa 0.25.0",
  "core-foundation 0.9.4",
@@ -2721,6 +2749,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -3502,6 +3531,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/lib.rs"
 # Core
 tokio = { version = "1.35", features = ["full"] }
 anyhow = "1.0"
+async-trait = "0.1"
 thiserror = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -49,7 +50,7 @@ rubato = "0.16"
 realfft = "3.4"
 
 # HTTP client (for model download)，用 rustls 避免 Linux 上依赖系统 OpenSSL
-reqwest = { version = "0.12", features = ["stream", "rustls-tls"], default-features = false }
+reqwest = { version = "0.12", features = ["stream", "rustls-tls", "multipart"], default-features = false }
 
 # Utils（放 [dependencies] 内，保证 Linux/macOS/Windows 都能用）
 uuid = { version = "1.6", features = ["v4"] }

--- a/src/asr/groq.rs
+++ b/src/asr/groq.rs
@@ -1,0 +1,139 @@
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use tracing::info;
+
+use super::AsrProvider;
+use crate::common::types::TranscriptionResult;
+
+pub struct GroqAsrProvider {
+    api_key: String,
+    model: String,
+    language: String,
+    client: reqwest::Client,
+}
+
+impl GroqAsrProvider {
+    pub fn new(api_key: String, model: String, language: String) -> Result<Self> {
+        if api_key.trim().is_empty() {
+            anyhow::bail!(
+                "Groq API key is required. Set GROQ_API_KEY env var or groq_api_key in config.toml"
+            );
+        }
+        Ok(Self {
+            api_key,
+            model,
+            language,
+            client: reqwest::Client::new(),
+        })
+    }
+}
+
+#[async_trait]
+impl AsrProvider for GroqAsrProvider {
+    async fn transcribe(&self, audio: &[f32], sample_rate: u32) -> Result<TranscriptionResult> {
+        let start = std::time::Instant::now();
+        info!(
+            "Groq transcription: {} samples @ {}Hz, model={}",
+            audio.len(),
+            sample_rate,
+            self.model
+        );
+
+        // Encode PCM f32 to WAV in memory
+        let wav_bytes = encode_wav(audio, sample_rate)?;
+
+        let file_part = reqwest::multipart::Part::bytes(wav_bytes)
+            .file_name("audio.wav")
+            .mime_str("audio/wav")?;
+
+        let mut form = reqwest::multipart::Form::new()
+            .text("model", self.model.clone())
+            .part("file", file_part);
+
+        if !self.language.is_empty() {
+            form = form.text("language", self.language.clone());
+        }
+
+        let res = self
+            .client
+            .post("https://api.groq.com/openai/v1/audio/transcriptions")
+            .bearer_auth(&self.api_key)
+            .multipart(form)
+            .timeout(std::time::Duration::from_secs(30))
+            .send()
+            .await
+            .context("Groq API request failed")?;
+
+        if !res.status().is_success() {
+            let status = res.status();
+            let body = res.text().await.unwrap_or_default();
+            return Err(anyhow!("Groq transcription failed: {} {}", status, body));
+        }
+
+        let body = res.text().await.context("Failed to read Groq response body")?;
+        let parsed: GroqTranscriptionResponse =
+            serde_json::from_str(&body).context("Failed to parse Groq response JSON")?;
+
+        let duration_ms = start.elapsed().as_millis() as u64;
+        info!(
+            "Groq transcription complete: {}ms, text length={}",
+            duration_ms,
+            parsed.text.len()
+        );
+
+        Ok(TranscriptionResult {
+            text: parsed.text,
+            confidence: 1.0,
+            language: if self.language.is_empty() {
+                None
+            } else {
+                Some(self.language.clone())
+            },
+            duration_ms,
+        })
+    }
+
+    fn check_status(&self) -> Result<String> {
+        if self.api_key.trim().is_empty() {
+            anyhow::bail!("Groq API key not configured")
+        }
+        Ok(format!("ready (model: {})", self.model))
+    }
+
+    fn name(&self) -> &str {
+        "groq (Whisper)"
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct GroqTranscriptionResponse {
+    text: String,
+}
+
+/// Encode f32 PCM samples to WAV bytes in memory.
+fn encode_wav(samples: &[f32], sample_rate: u32) -> Result<Vec<u8>> {
+    use std::io::Cursor;
+
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+
+    let mut cursor = Cursor::new(Vec::new());
+    {
+        let mut writer =
+            hound::WavWriter::new(&mut cursor, spec).context("Failed to create WAV writer")?;
+        for &s in samples {
+            let clamped = s.clamp(-1.0, 1.0);
+            let i16_val = (clamped * 32767.0) as i16;
+            writer
+                .write_sample(i16_val)
+                .context("Failed to write WAV sample")?;
+        }
+        writer.finalize().context("Failed to finalize WAV")?;
+    }
+
+    Ok(cursor.into_inner())
+}

--- a/src/asr/mod.rs
+++ b/src/asr/mod.rs
@@ -1,9 +1,12 @@
 pub mod decoder;
+pub mod groq;
 pub mod onnx_inference;
 pub mod preprocess;
 
 use anyhow::{Context, Result};
+use async_trait::async_trait;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tracing::{info, warn};
 
@@ -11,6 +14,26 @@ use crate::asr::decoder::CTCDecoder;
 use crate::asr::onnx_inference::OnnxInference;
 use crate::asr::preprocess::{AudioPreprocessor, TARGET_SAMPLE_RATE};
 use crate::common::types::TranscriptionResult;
+
+/// Trait abstracting speech recognition backends (local ONNX vs cloud API).
+#[async_trait]
+pub trait AsrProvider: Send + Sync {
+    /// Transcribe PCM audio samples. Returns transcribed text.
+    async fn transcribe(&self, audio: &[f32], sample_rate: u32) -> Result<TranscriptionResult>;
+
+    /// Optional warmup (e.g. load model, establish connection). Default no-op.
+    async fn warmup(&self) -> Result<()> {
+        Ok(())
+    }
+
+    /// Check provider readiness. Returns human-readable status string on success.
+    fn check_status(&self) -> Result<String> {
+        Ok("ready".into())
+    }
+
+    /// Provider name for display purposes.
+    fn name(&self) -> &str;
+}
 
 /// 调试与调参用环境变量（可开关）：
 /// - OPEN_FLOW_DEBUG_ASR: 打印 features shape、encoder_out_lens、logits 首/中/末帧 top-k 及 non_blank 帧数
@@ -319,6 +342,61 @@ pub struct AsrStatus {
     #[allow(dead_code)]
     pub tokens_exists: bool,
     pub ready: bool,
+}
+
+/// Local ASR provider wrapping the existing ONNX-based AsrEngine.
+/// Uses Arc<Mutex<>> so the engine can be moved into spawn_blocking.
+pub struct LocalAsrProvider {
+    engine: Arc<Mutex<AsrEngine>>,
+}
+
+impl LocalAsrProvider {
+    pub fn new(model_path: PathBuf) -> Self {
+        Self {
+            engine: Arc::new(Mutex::new(AsrEngine::new(model_path))),
+        }
+    }
+}
+
+#[async_trait]
+impl AsrProvider for LocalAsrProvider {
+    async fn transcribe(&self, audio: &[f32], sample_rate: u32) -> Result<TranscriptionResult> {
+        let audio = audio.to_vec();
+        let engine = self.engine.clone();
+        tokio::task::spawn_blocking(move || {
+            engine.lock().unwrap().transcribe_pcm(&audio, sample_rate)
+        })
+        .await
+        .context("spawn_blocking failed")?
+    }
+
+    async fn warmup(&self) -> Result<()> {
+        let engine = self.engine.clone();
+        tokio::task::spawn_blocking(move || {
+            engine.lock().unwrap().warmup();
+        })
+        .await
+        .context("warmup spawn_blocking failed")?;
+        Ok(())
+    }
+
+    fn check_status(&self) -> Result<String> {
+        let status = self.engine.lock().unwrap().check_status();
+        if status.ready {
+            Ok("ready".into())
+        } else {
+            anyhow::bail!(
+                "Model not ready: {:?} (onnx={}, model={})",
+                status.model_path,
+                status.onnx_exists,
+                status.model_exists
+            )
+        }
+    }
+
+    fn name(&self) -> &str {
+        "local (SenseVoice)"
+    }
 }
 
 #[cfg(test)]

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -230,13 +230,23 @@ impl AudioCapture {
             error!("❌ 音频采集错误: {}", err);
         };
 
+        let channels = self.channels as usize;
+
         let stream = match self.sample_format {
             SampleFormat::F32 => {
                 let buf = buffer.clone();
                 self.device.build_input_stream(
                     &self.config,
                     move |data: &[f32], _: &cpal::InputCallbackInfo| {
-                        buf.lock().unwrap().extend_from_slice(data);
+                        if let Ok(mut b) = buf.lock() {
+                            if channels > 1 {
+                                for chunk in data.chunks(channels) {
+                                    b.push(chunk.iter().sum::<f32>() / channels as f32);
+                                }
+                            } else {
+                                b.extend_from_slice(data);
+                            }
+                        }
                     },
                     err_fn,
                     None,
@@ -247,9 +257,15 @@ impl AudioCapture {
                 self.device.build_input_stream(
                     &self.config,
                     move |data: &[i16], _: &cpal::InputCallbackInfo| {
-                        let mut b = buf.lock().unwrap();
-                        for &s in data {
-                            b.push(s as f32 / 32768.0);
+                        if let Ok(mut b) = buf.lock() {
+                            if channels > 1 {
+                                for chunk in data.chunks(channels) {
+                                    let mixed = chunk.iter().map(|&s| s as f32 / 32768.0).sum::<f32>() / channels as f32;
+                                    b.push(mixed);
+                                }
+                            } else {
+                                b.extend(data.iter().map(|&s| s as f32 / 32768.0));
+                            }
                         }
                     },
                     err_fn,
@@ -261,9 +277,15 @@ impl AudioCapture {
                 self.device.build_input_stream(
                     &self.config,
                     move |data: &[u16], _: &cpal::InputCallbackInfo| {
-                        let mut b = buf.lock().unwrap();
-                        for &s in data {
-                            b.push((s as f32 - 32768.0) / 32768.0);
+                        if let Ok(mut b) = buf.lock() {
+                            if channels > 1 {
+                                for chunk in data.chunks(channels) {
+                                    let mixed = chunk.iter().map(|&s| (s as f32 - 32768.0) / 32768.0).sum::<f32>() / channels as f32;
+                                    b.push(mixed);
+                                }
+                            } else {
+                                b.extend(data.iter().map(|&s| (s as f32 - 32768.0) / 32768.0));
+                            }
                         }
                     },
                     err_fn,

--- a/src/cli/daemon.rs
+++ b/src/cli/daemon.rs
@@ -5,6 +5,8 @@ use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+use crate::asr::groq::GroqAsrProvider;
+use crate::asr::{AsrProvider, LocalAsrProvider};
 use crate::common::config::Config;
 use crate::daemon::run_daemon;
 use crate::tray::{TrayIconState, TrayState};
@@ -35,7 +37,18 @@ fn read_pid() -> Option<u32> {
 fn is_running(pid: u32) -> bool {
     #[cfg(unix)]
     {
-        unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+        if unsafe { libc::kill(pid as libc::pid_t, 0) } != 0 {
+            return false;
+        }
+        // 验证是否确实是 open-flow 进程，而不是被回收的 PID
+        if let Ok(output) = std::process::Command::new("ps")
+            .args(["-p", &pid.to_string(), "-o", "comm="])
+            .output()
+        {
+            let comm = String::from_utf8_lossy(&output.stdout);
+            return comm.trim().contains("open-flow");
+        }
+        true // ps 失败则假定是我们的进程
     }
     #[cfg(windows)]
     {
@@ -177,20 +190,40 @@ pub fn start_foreground(model: Option<PathBuf>) -> anyhow::Result<()> {
         }
     };
 
+    // ── 构建 ASR provider ──────────────────────────────────────────
+    let config = Config::load().unwrap_or_default();
+    let provider: Arc<dyn AsrProvider> = match config.provider.as_str() {
+        "groq" => {
+            let api_key = config.resolved_groq_api_key();
+            match GroqAsrProvider::new(api_key, config.groq_model.clone(), config.groq_language.clone()) {
+                Ok(p) => {
+                    println!("   Provider: Groq ({})", config.groq_model);
+                    Arc::new(p)
+                }
+                Err(e) => {
+                    eprintln!("⚠️  Groq provider 初始化失败: {}。回退到本地模式。", e);
+                    Arc::new(LocalAsrProvider::new(model_path.clone()))
+                }
+            }
+        }
+        _ => {
+            println!("   Provider: Local (SenseVoice)");
+            Arc::new(LocalAsrProvider::new(model_path.clone()))
+        }
+    };
+
     // ── 在专用线程运行 daemon（current_thread 运行时，Daemon 含 cpal::Stream 非 Send）
     let log = log_path()?;
     println!("✅ Open Flow 已启动 (PID: {})", my_pid);
-    println!("   模型: {:?}", model_path);
-    #[cfg(target_os = "macos")]
-    println!("   热键: 右 Command（固定）");
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
-    println!("   热键: 右侧 Alt 键（固定）");
-    #[cfg(all(not(target_os = "macos"), not(target_os = "windows"), not(target_os = "linux")))]
-    println!("   热键: 右 Meta/Super（固定）");
+    println!("   热键: {}", config.hotkey);
+    println!("   触发模式: {}", config.trigger_mode);
     println!("   日志: {}", log.display());
     println!();
     println!("   按 Ctrl+C 或托盘菜单「退出」可停止");
     println!("   ⏳ 模型加载与预热约需 3-5 秒，完成后热键即可使用");
+
+    let daemon_alive = Arc::new(AtomicBool::new(true));
+    let daemon_alive_clone = daemon_alive.clone();
 
     let daemon_handle = std::thread::spawn(move || {
         let rt = tokio::runtime::Builder::new_current_thread()
@@ -198,14 +231,15 @@ pub fn start_foreground(model: Option<PathBuf>) -> anyhow::Result<()> {
             .build()
             .expect("daemon tokio runtime");
         rt.block_on(async {
-            if let Err(e) = run_daemon(model_path, tray_handle).await {
+            if let Err(e) = run_daemon(provider, tray_handle).await {
                 eprintln!("Daemon 错误: {}", e);
             }
         });
+        daemon_alive_clone.store(false, Ordering::SeqCst);
     });
 
     // ── 主线程：驱动 macOS NSRunLoop，让托盘 / 菜单事件得以分发 ──────
-    run_main_loop(tray.as_ref());
+    run_main_loop(tray.as_ref(), &daemon_alive);
 
     // ── 退出前显式隐藏菜单栏图标并 pump run loop，避免图标残留
     if let Some(ref t) = tray {
@@ -219,14 +253,28 @@ pub fn start_foreground(model: Option<PathBuf>) -> anyhow::Result<()> {
 
     // ── 退出清理 ──────────────────────────────────────────────────────
     remove_pid_file();
-    let _ = daemon_handle.join();
+
+    // 给 daemon 线程短时间优雅退出
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+    while std::time::Instant::now() < deadline {
+        if daemon_handle.is_finished() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
     println!("\n👋 Open Flow 已停止");
-    Ok(())
+
+    // 强制退出——daemon 线程可能阻塞在 tokio recv() 或 CFRunLoop 上
+    std::process::exit(0);
 }
 
 /// macOS 主循环：每 100ms 执行一次 NSRunLoop，检查是否需要退出。
 /// 这是让 tray-icon 在 macOS 上正常渲染和响应菜单的关键。
-fn run_main_loop(tray: Option<&TrayState>) {
+fn run_main_loop(
+    tray: Option<&TrayState>,
+    daemon_alive: &AtomicBool,
+) {
     loop {
         // 应用 daemon 发来的托盘状态更新（灰/红/黄）
         if let Some(t) = tray {
@@ -255,6 +303,11 @@ fn run_main_loop(tray: Option<&TrayState>) {
         // SIGTERM / SIGINT（open-flow stop 或 Ctrl+C）
         if SIGNAL_SHUTDOWN.load(Ordering::SeqCst) {
             tracing::info!("收到信号，正常退出");
+            break;
+        }
+        // daemon 线程意外退出
+        if !daemon_alive.load(Ordering::SeqCst) {
+            tracing::error!("Daemon 线程已意外退出");
             break;
         }
     }
@@ -299,8 +352,8 @@ fn prepare_appkit() {
 
         static INIT: std::sync::Once = std::sync::Once::new();
         INIT.call_once(|| {
-            // NSApplicationActivationPolicyRegular = 0
-            let _: () = msg_send![app, setActivationPolicy: 0i64];
+            // NSApplicationActivationPolicyAccessory = 1（无 Dock 图标，但可以有窗口）
+            let _: () = msg_send![app, setActivationPolicy: 1i64];
             let _: () = msg_send![app, finishLaunching];
         });
     }
@@ -383,6 +436,9 @@ pub async fn stop() -> Result<()> {
             }
         }
         unsafe { libc::kill(pid as libc::pid_t, libc::SIGKILL) };
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        remove_pid_file();
+        println!("✅ daemon 已停止（强制终止）");
     }
 
     #[cfg(windows)]
@@ -414,17 +470,14 @@ pub async fn status() -> Result<()> {
         Some(pid) if is_running(pid) => {
             let uptime = get_uptime_str(pid);
             println!("Open Flow daemon 状态");
-            println!("  状态:   ✅ 运行中");
-            println!("  PID:    {}", pid);
-            println!("  运行:   {}", uptime);
-            println!("  模型:   {:?}", config.model_path.unwrap_or_default());
-            #[cfg(target_os = "macos")]
-            println!("  热键:   右 Command（固定）");
-            #[cfg(any(target_os = "windows", target_os = "linux"))]
-            println!("  热键:   右侧 Alt 键（固定）");
-            #[cfg(all(not(target_os = "macos"), not(target_os = "windows"), not(target_os = "linux")))]
-            println!("  热键:   右 Meta/Super（固定）");
-            println!("  日志:   {}", log_path()?.display());
+            println!("  状态:     ✅ 运行中");
+            println!("  PID:      {}", pid);
+            println!("  运行:     {}", uptime);
+            println!("  模型:     {:?}", config.model_path.unwrap_or_default());
+            println!("  Provider: {}", config.provider);
+            println!("  热键:     {}", config.hotkey);
+            println!("  触发模式: {}", config.trigger_mode);
+            println!("  日志:     {}", log_path()?.display());
         }
         Some(pid) => {
             println!("Open Flow daemon 状态");

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -10,17 +10,59 @@ const CONFIG_FILE: &str = "config.toml";
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     pub model_path: Option<PathBuf>,
+    /// "local" or "groq"
+    #[serde(default = "default_provider")]
+    pub provider: String,
+    /// Groq API key (env var GROQ_API_KEY takes precedence)
+    #[serde(default)]
+    pub groq_api_key: String,
+    /// Groq Whisper model name
+    #[serde(default = "default_groq_model")]
+    pub groq_model: String,
+    /// Optional language hint for Groq (e.g. "en", "zh"). Empty = auto-detect.
+    #[serde(default)]
+    pub groq_language: String,
+    /// Hotkey identifier: "right_cmd", "fn", "f13", etc.
+    #[serde(default = "default_hotkey")]
+    pub hotkey: String,
+    /// Trigger mode: "toggle" or "hold"
+    #[serde(default = "default_trigger_mode")]
+    pub trigger_mode: String,
+}
+
+fn default_provider() -> String {
+    "local".into()
+}
+fn default_groq_model() -> String {
+    "whisper-large-v3-turbo".into()
+}
+fn default_hotkey() -> String {
+    "right_cmd".into()
+}
+fn default_trigger_mode() -> String {
+    "toggle".into()
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             model_path: None,
+            provider: default_provider(),
+            groq_api_key: String::new(),
+            groq_model: default_groq_model(),
+            groq_language: String::new(),
+            hotkey: default_hotkey(),
+            trigger_mode: default_trigger_mode(),
         }
     }
 }
 
 impl Config {
+    /// Returns Groq API key: env var GROQ_API_KEY takes precedence over config file.
+    pub fn resolved_groq_api_key(&self) -> String {
+        std::env::var("GROQ_API_KEY").unwrap_or_else(|_| self.groq_api_key.clone())
+    }
+
     pub fn load() -> Result<Self> {
         let config_path = Self::config_path()?;
 
@@ -43,13 +85,19 @@ impl Config {
             }
         }
 
+        if config.model_path.as_ref().map_or(false, |p| p.as_os_str().is_empty()) {
+            config.model_path = None;
+        }
+
         Ok(config)
     }
 
     pub fn save(&self) -> Result<()> {
         let config_path = Self::config_path()?;
         let content = toml::to_string_pretty(self)?;
-        fs::write(config_path, content)?;
+        let tmp = config_path.with_extension("toml.tmp");
+        fs::write(&tmp, &content)?;
+        fs::rename(&tmp, &config_path)?;
         Ok(())
     }
 

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -16,4 +16,7 @@ pub struct TranscriptionResult {
 
 /// 热键触发事件（右 Command 按下）
 #[derive(Debug, Clone)]
-pub struct HotkeyEvent;
+pub enum HotkeyEvent {
+    Pressed,
+    Released,
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1,11 +1,10 @@
 use anyhow::{Context, Result};
-use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
-use tracing::{info, warn};
+use tracing::info;
 
-use crate::asr::AsrEngine;
+use crate::asr::AsrProvider;
 use crate::audio::AudioCapture;
 use crate::common::types::{HotkeyEvent, RecordingState};
 use crate::hotkey::{
@@ -29,9 +28,8 @@ pub struct Daemon {
     is_processing: AtomicBool,
     /// 已收到的热键事件次数（用于日志：第 N 次按键）
     hotkey_recv_count: std::sync::atomic::AtomicU64,
-    model_path: PathBuf,
     audio_capture: AudioCapture,
-    asr_engine: Arc<Mutex<AsrEngine>>,
+    provider: Arc<dyn AsrProvider>,
     text_injector: TextInjector,
     /// 当前录音流（Some = 正在录音，drop 即停止）
     active_stream: Mutex<Option<cpal::Stream>>,
@@ -39,28 +37,30 @@ pub struct Daemon {
     recording_buffer: Mutex<Arc<Mutex<Vec<f32>>>>,
     /// 托盘句柄（Send+Sync，状态更新发回主线程）
     tray: Option<Arc<TrayHandle>>,
+    /// 触发模式: "toggle" or "hold"
+    trigger_mode: String,
 }
 
 impl Daemon {
     pub fn new(
-        model_path: PathBuf,
+        provider: Arc<dyn AsrProvider>,
         tray: Option<Arc<TrayHandle>>,
     ) -> Result<Self> {
         let audio_capture = AudioCapture::new().context("初始化音频采集器失败")?;
-        let asr_engine = Arc::new(Mutex::new(AsrEngine::new(model_path.clone())));
         let text_injector = TextInjector::new();
+        let config = crate::common::config::Config::load().unwrap_or_default();
 
         Ok(Self {
             state: Arc::new(Mutex::new(RecordingState::default())),
             is_processing: AtomicBool::new(false),
             hotkey_recv_count: std::sync::atomic::AtomicU64::new(0),
-            model_path,
             audio_capture,
-            asr_engine,
+            provider,
             text_injector,
             active_stream: Mutex::new(None),
             recording_buffer: Mutex::new(Arc::new(Mutex::new(Vec::new()))),
             tray,
+            trigger_mode: config.trigger_mode,
         })
     }
 
@@ -81,54 +81,50 @@ impl Daemon {
         println!("   Accessibility: {}", accessibility_ok);
         println!("   Input Monitoring: {}", input_monitoring_ok);
         println!("   Microphone: {}", microphone_ok);
-        if !microphone_ok {
-            println!();
-            println!("⚠️  缺少麦克风权限！录音将为静音，无法转写。");
-            println!("   请前往：系统设置 > 隐私与安全性 > 麦克风");
-            println!("   将 Open Flow.app 添加并启用，然后完全退出并重新打开。");
-        }
 
-        // ── Accessibility 权限检查 ───────────────────────────────────
+        // 请求缺失的权限（触发系统对话框）
         if !accessibility_ok {
-            warn!("Accessibility 权限检查失败，可能是 TCC 将当前可执行文件识别为新身份");
-            request_accessibility_permission();
             println!();
-            println!("授权后请完全退出并重新打开 Open Flow。");
-            anyhow::bail!("缺少 Accessibility 权限");
+            println!("⚠️  Accessibility 权限未授权——正在请求...");
+            request_accessibility_permission();
         }
         if !input_monitoring_ok {
-            warn!("Input Monitoring 权限检查失败，可能是 TCC 将当前可执行文件识别为新身份");
-            crate::hotkey::request_input_monitoring_permission();
             println!();
-            println!("授权后请完全退出并重新打开 Open Flow。");
-            anyhow::bail!("缺少 Input Monitoring 权限");
+            println!("⚠️  Input Monitoring 权限未授权——正在请求...");
+            crate::hotkey::request_input_monitoring_permission();
+        }
+        if !microphone_ok {
+            println!();
+            println!("⚠️  麦克风权限尚未授权。");
+            crate::hotkey::request_microphone_permission();
         }
 
-        // ── ASR 状态 ─────────────────────────────────────────────────
-        let asr_status = self.asr_engine.lock().unwrap().check_status();
-        if !asr_status.ready {
-            anyhow::bail!(
-                "模型未就绪：{:?}\n  onnx={} mvn={}",
-                asr_status.model_path,
-                asr_status.onnx_exists,
-                asr_status.model_exists,
-            );
+        if !accessibility_ok || !input_monitoring_ok {
+            println!();
+            println!("⏳ 等待权限授权... 请在系统设置中授权，然后应用将重试。");
+            println!("   （如果授权后热键不工作，请重启应用）");
         }
 
-        // ── 模型预热（消除首次推理 JIT 开销）──────────────────────────
+        // ── Provider 状态检查 ──────────────────────────────────────────
+        if let Err(e) = self.provider.check_status() {
+            anyhow::bail!("Provider 未就绪: {}", e);
+        }
+
+        // ── Provider 预热（消除首次推理 JIT 开销）──────────────────────
         {
             let warmup_start = std::time::Instant::now();
-            self.asr_engine.lock().unwrap().warmup();
+            self.provider.warmup().await?;
             let warmup_ms = warmup_start.elapsed().as_millis();
-            info!("模型预热耗时: {}ms", warmup_ms);
+            info!("Provider 预热耗时: {}ms", warmup_ms);
         }
 
         // ── 音频设备信息 ──────────────────────────────────────────────
         let audio_info = self.audio_capture.get_info();
 
         // ── 启动热键监听器 ─────────────────────────────────────────────
+        let config = crate::common::config::Config::load().unwrap_or_default();
         let (hotkey_tx, hotkey_rx) = std::sync::mpsc::channel();
-        let listener = HotkeyListener::new(hotkey_tx);
+        let listener = HotkeyListener::new(hotkey_tx, config.hotkey.clone());
         listener.start().context("启动热键监听器失败")?;
 
         // ── 把同步 mpsc 桥接到 tokio mpsc ─────────────────────────────
@@ -159,9 +155,9 @@ impl Daemon {
             "   音频设备: {}Hz / {} 通道",
             audio_info.sample_rate, audio_info.channels
         );
-        println!("   模型路径: {:?}", self.model_path);
+        println!("   Provider: {}", self.provider.name());
         println!();
-        println!("🎙️  按右侧 Command 键开始录音，再按一次停止并转写");
+        println!("🎙️  按热键开始录音，再按一次停止并转写");
         println!("   托盘图标可查看状态（灰=待机 红=录音 黄=转写）");
         println!();
 
@@ -174,11 +170,10 @@ impl Daemon {
                             self.handle_hotkey(ev, &event_tx).await;
                         }
                         DaemonEvent::TranscriptionComplete(text) => {
+                            self.is_processing.store(false, Ordering::SeqCst);
                             self.set_tray(TrayIconState::Idle);
                             println!("📝 转写完成: {}", text);
-                            // 延迟 250ms 再粘贴，避免与用户紧接着的「第三次按键」重叠：
-                            // inject 模拟左 Command+V 会干扰 CGEventTap，导致右 Command 的 KeyPress 丢失、只收到 Release
-                            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
                             info!("[Hotkey] 开始粘贴");
                             if let Err(e) = self.text_injector.inject(&text).await {
                                 eprintln!("⚠️  文字注入失败: {e}");
@@ -210,32 +205,61 @@ impl Daemon {
         }
     }
 
-    async fn handle_hotkey(&self, _event: HotkeyEvent, tx: &mpsc::Sender<DaemonEvent>) {
+    async fn handle_hotkey(&self, event: HotkeyEvent, tx: &mpsc::Sender<DaemonEvent>) {
         let n = self.hotkey_recv_count.fetch_add(1, Ordering::SeqCst) + 1;
         let is_processing = self.is_processing.load(Ordering::SeqCst);
         let is_recording = self.state.lock().unwrap().is_recording;
         info!(
-            "[Hotkey] 收到第 {} 次按键 is_recording={} is_processing={}",
-            n, is_recording, is_processing
+            "[Hotkey] 收到第 {} 次按键 event={:?} is_recording={} is_processing={} mode={}",
+            n, event, is_recording, is_processing, self.trigger_mode
         );
-        if is_processing {
-            info!("[Hotkey] 第 {} 次 -> 忽略（转写中）", n);
-            return;
-        }
-        if is_recording {
-            info!("[Hotkey] 第 {} 次 -> 动作: 停止录音并转写", n);
-            self.set_tray(TrayIconState::Transcribing);
-            let res = self.stop_and_transcribe(tx).await;
-            if let Err(e) = res {
-                self.set_tray(TrayIconState::Idle);
-                eprintln!("⚠️  转写失败: {e}");
+
+        match event {
+            HotkeyEvent::Pressed => {
+                if is_processing {
+                    info!("[Hotkey] 第 {} 次 -> 忽略（转写中）", n);
+                    return;
+                }
+                if self.trigger_mode == "hold" {
+                    // Hold 模式: Pressed 始终开始录音
+                    if !is_recording {
+                        info!("[Hotkey] 第 {} 次 -> 动作: 开始录音（hold 模式）", n);
+                        if let Err(e) = self.start_recording() {
+                            eprintln!("⚠️  录音启动失败: {e}");
+                        } else {
+                            self.set_tray(TrayIconState::Recording);
+                        }
+                    }
+                } else {
+                    // Toggle 模式: Pressed 切换状态
+                    if is_recording {
+                        info!("[Hotkey] 第 {} 次 -> 动作: 停止录音并转写（toggle 模式）", n);
+                        self.set_tray(TrayIconState::Transcribing);
+                        if let Err(e) = self.stop_and_transcribe(tx).await {
+                            self.set_tray(TrayIconState::Idle);
+                            eprintln!("⚠️  转写失败: {e}");
+                        }
+                    } else {
+                        info!("[Hotkey] 第 {} 次 -> 动作: 开始录音（toggle 模式）", n);
+                        if let Err(e) = self.start_recording() {
+                            eprintln!("⚠️  录音启动失败: {e}");
+                        } else {
+                            self.set_tray(TrayIconState::Recording);
+                        }
+                    }
+                }
             }
-        } else {
-            info!("[Hotkey] 第 {} 次 -> 动作: 开始录音", n);
-            if let Err(e) = self.start_recording() {
-                eprintln!("⚠️  录音启动失败: {e}");
-            } else {
-                self.set_tray(TrayIconState::Recording);
+            HotkeyEvent::Released => {
+                if self.trigger_mode == "hold" && is_recording {
+                    // Hold 模式: Released 始终停止
+                    info!("[Hotkey] 第 {} 次 -> 动作: 停止录音并转写（hold 松开）", n);
+                    self.set_tray(TrayIconState::Transcribing);
+                    if let Err(e) = self.stop_and_transcribe(tx).await {
+                        self.set_tray(TrayIconState::Idle);
+                        eprintln!("⚠️  转写失败: {e}");
+                    }
+                }
+                // Toggle 模式: Released 忽略
             }
         }
     }
@@ -259,7 +283,7 @@ impl Daemon {
         state.start_time = Some(std::time::Instant::now());
 
         info!("[Hotkey] 录音已启动");
-        println!("🔴 录音中... 再按右侧 Command 键停止");
+        println!("🔴 录音中... 再按热键停止");
         Ok(())
     }
 
@@ -313,23 +337,21 @@ impl Daemon {
             return Ok(());
         }
 
-        // 直接把内存中的 PCM 数据送给 ASR，不经过磁盘文件
+        // 通过 AsrProvider trait 进行转写（本地或云端）
         let sample_rate = self.audio_capture.get_info().sample_rate;
-        let asr_engine = self.asr_engine.clone();
-        let infer_fut = tokio::task::spawn_blocking(move || {
-            asr_engine
-                .lock()
-                .unwrap()
-                .transcribe_pcm(&buffer, sample_rate)
-        });
+        let provider = self.provider.clone();
 
-        let join_result = match tokio::time::timeout(
+        let result = match tokio::time::timeout(
             std::time::Duration::from_secs(30),
-            infer_fut,
+            provider.transcribe(&buffer, sample_rate),
         )
         .await
         {
-            Ok(r) => r,
+            Ok(Ok(r)) => r,
+            Ok(Err(e)) => {
+                self.is_processing.store(false, Ordering::SeqCst);
+                return Err(e);
+            }
             Err(_elapsed) => {
                 self.is_processing.store(false, Ordering::SeqCst);
                 eprintln!("⚠️  转写超时（>30s），已放弃，请检查模型或重启 daemon");
@@ -337,23 +359,6 @@ impl Daemon {
             }
         };
 
-        let result = match join_result {
-            Ok(r) => r,
-            Err(e) => {
-                self.is_processing.store(false, Ordering::SeqCst);
-                return Err(anyhow::anyhow!("spawn_blocking failed: {}", e));
-            }
-        };
-        let result = match result {
-            Ok(r) => r,
-            Err(e) => {
-                self.is_processing.store(false, Ordering::SeqCst);
-                return Err(e);
-            }
-        };
-
-        // 在发送前清除，避免：Hotkey(P3) 先于 TranscriptionComplete 被处理时被误忽略
-        self.is_processing.store(false, Ordering::SeqCst);
         tx.send(DaemonEvent::TranscriptionComplete(result.text))
             .await
             .ok();
@@ -363,9 +368,9 @@ impl Daemon {
 }
 
 pub async fn run_daemon(
-    model_path: PathBuf,
+    provider: Arc<dyn AsrProvider>,
     tray: Option<Arc<TrayHandle>>,
 ) -> Result<()> {
-    let daemon = Daemon::new(model_path, tray)?;
+    let daemon = Daemon::new(provider, tray)?;
     daemon.run().await
 }

--- a/src/hotkey/mod.rs
+++ b/src/hotkey/mod.rs
@@ -9,19 +9,21 @@ use crate::common::types::HotkeyEvent;
 /// 热键监听器，通过 rdev（底层 CGEventTap）监听全局按键事件
 pub struct HotkeyListener {
     sender: Sender<HotkeyEvent>,
+    hotkey: String,
 }
 
 impl HotkeyListener {
-    pub fn new(sender: Sender<HotkeyEvent>) -> Self {
-        Self { sender }
+    pub fn new(sender: Sender<HotkeyEvent>, hotkey: String) -> Self {
+        Self { sender, hotkey }
     }
 
     /// 在独立线程启动热键监听
     pub fn start(self) -> Result<()> {
-        info!("正在启动热键监听器（右侧 Command 键，基于 CGEventTap）...");
+        info!("正在启动热键监听器（热键: {}）...", self.hotkey);
 
+        let hotkey = self.hotkey.clone();
         thread::spawn(move || {
-            if let Err(e) = Self::run_listen_loop(self.sender) {
+            if let Err(e) = Self::run_listen_loop(self.sender, &hotkey) {
                 error!("热键监听错误: {}", e);
             }
         });
@@ -29,27 +31,28 @@ impl HotkeyListener {
         Ok(())
     }
 
-    fn run_listen_loop(sender: Sender<HotkeyEvent>) -> Result<()> {
+    fn run_listen_loop(sender: Sender<HotkeyEvent>, hotkey: &str) -> Result<()> {
         #[cfg(target_os = "macos")]
         {
-            return Self::run_listen_loop_macos(sender);
+            return Self::run_listen_loop_macos(sender, hotkey);
         }
 
         #[cfg(not(target_os = "macos"))]
         {
-            return Self::run_listen_loop_rdev(sender);
+            return Self::run_listen_loop_rdev(sender, hotkey);
         }
     }
 
     #[cfg(target_os = "macos")]
-    fn run_listen_loop_macos(sender: Sender<HotkeyEvent>) -> Result<()> {
+    fn run_listen_loop_macos(sender: Sender<HotkeyEvent>, hotkey: &str) -> Result<()> {
         use core_foundation::runloop::{kCFRunLoopCommonModes, CFRunLoop};
         use core_graphics::event::{
-            CGEventFlags, CGEventTap, CGEventTapLocation, CGEventTapOptions, CGEventType, EventField,
-            KeyCode,
+            CGEventFlags, CGEventTap, CGEventTapLocation, CGEventTapOptions, CGEventType,
+            EventField, KeyCode,
         };
         use std::sync::atomic::{AtomicBool, AtomicU64};
 
+        let is_fn_key = hotkey == "fn";
         let pressed = Arc::new(AtomicBool::new(false));
         let pressed_clone = pressed.clone();
         let press_count = Arc::new(AtomicU64::new(0));
@@ -57,7 +60,12 @@ impl HotkeyListener {
         let pc = press_count.clone();
         let rc = release_count.clone();
 
-        println!("⌨️  热键监听器已启动（CGEventTap）");
+        let key_name = if is_fn_key {
+            "Fn"
+        } else {
+            "右侧 Command"
+        };
+        println!("⌨️  热键监听器已启动（CGEventTap，热键: {}）", key_name);
 
         let current = CFRunLoop::get_current();
         let tap = CGEventTap::new(
@@ -70,33 +78,66 @@ impl HotkeyListener {
                     return None;
                 }
 
-                let keycode =
-                    event.get_integer_value_field(EventField::KEYBOARD_EVENT_KEYCODE) as u16;
-                if keycode != KeyCode::RIGHT_COMMAND {
-                    return None;
-                }
+                if is_fn_key {
+                    // Fn key: detect via secondary Fn flag (0x800000)
+                    let flags = event.get_flags();
+                    let fn_down = (flags.bits() & 0x800000) != 0;
 
-                let is_pressed = event.get_flags().contains(CGEventFlags::CGEventFlagCommand);
-                if is_pressed {
-                    let was = pressed_clone.swap(true, Ordering::SeqCst);
-                    if !was {
-                        let n = pc.fetch_add(1, Ordering::SeqCst) + 1;
+                    if fn_down {
+                        let was = pressed_clone.swap(true, Ordering::SeqCst);
+                        if !was {
+                            let n = pc.fetch_add(1, Ordering::SeqCst) + 1;
+                            info!(
+                                "[Hotkey] 事件 #press={} 按下（Fn）",
+                                n
+                            );
+                            if let Err(e) = sender.send(HotkeyEvent::Pressed) {
+                                error!("发送热键事件失败: {}", e);
+                            }
+                        }
+                    } else if pressed_clone.load(Ordering::SeqCst) {
+                        pressed_clone.store(false, Ordering::SeqCst);
+                        let n = rc.fetch_add(1, Ordering::SeqCst) + 1;
                         info!(
-                            "[Hotkey] 事件 #press={} 按下（右侧 Command）was_pressed={} -> 发送",
-                            n, was
+                            "[Hotkey] 事件 #release={} 松开（Fn）",
+                            n
                         );
-                        if let Err(e) = sender.send(HotkeyEvent) {
+                        if let Err(e) = sender.send(HotkeyEvent::Released) {
                             error!("发送热键事件失败: {}", e);
                         }
                     }
                 } else {
-                    let was = pressed_clone.swap(false, Ordering::SeqCst);
-                    if was {
-                        let n = rc.fetch_add(1, Ordering::SeqCst) + 1;
-                        info!(
-                            "[Hotkey] 事件 #release={} 松开（右侧 Command）was_pressed={}",
-                            n, was
-                        );
+                    let keycode =
+                        event.get_integer_value_field(EventField::KEYBOARD_EVENT_KEYCODE) as u16;
+                    if keycode != KeyCode::RIGHT_COMMAND {
+                        return None;
+                    }
+
+                    let is_pressed = event.get_flags().contains(CGEventFlags::CGEventFlagCommand);
+                    if is_pressed {
+                        let was = pressed_clone.swap(true, Ordering::SeqCst);
+                        if !was {
+                            let n = pc.fetch_add(1, Ordering::SeqCst) + 1;
+                            info!(
+                                "[Hotkey] 事件 #press={} 按下（右侧 Command）was_pressed={} -> 发送",
+                                n, was
+                            );
+                            if let Err(e) = sender.send(HotkeyEvent::Pressed) {
+                                error!("发送热键事件失败: {}", e);
+                            }
+                        }
+                    } else {
+                        let was = pressed_clone.swap(false, Ordering::SeqCst);
+                        if was {
+                            let n = rc.fetch_add(1, Ordering::SeqCst) + 1;
+                            info!(
+                                "[Hotkey] 事件 #release={} 松开（右侧 Command）was_pressed={}",
+                                n, was
+                            );
+                            if let Err(e) = sender.send(HotkeyEvent::Released) {
+                                error!("发送热键事件失败: {}", e);
+                            }
+                        }
                     }
                 }
 
@@ -118,7 +159,7 @@ impl HotkeyListener {
     }
 
     #[cfg(not(target_os = "macos"))]
-    fn run_listen_loop_rdev(sender: Sender<HotkeyEvent>) -> Result<()> {
+    fn run_listen_loop_rdev(sender: Sender<HotkeyEvent>, _hotkey: &str) -> Result<()> {
         use rdev::{listen, Event, EventType, Key};
         use std::sync::atomic::{AtomicBool, AtomicU64};
 
@@ -133,25 +174,34 @@ impl HotkeyListener {
 
         // Windows / Linux: 右侧 Alt（AltGr）；与 macOS 右 Command 区分
         let result = listen(move |event: Event| {
-            let hotkey_press = matches!(event.event_type, EventType::KeyPress(Key::AltGr));
-            let hotkey_release = matches!(event.event_type, EventType::KeyRelease(Key::AltGr));
-            if hotkey_press {
-                let n = pc.fetch_add(1, Ordering::SeqCst) + 1;
-                let was = pressed_clone.swap(true, Ordering::SeqCst);
-                info!(
-                    "[Hotkey] 事件 #press={} 按下（右侧 Alt）was_pressed={} -> 发送",
-                    n, was
-                );
-                if let Err(e) = sender.send(HotkeyEvent) {
-                    error!("发送热键事件失败: {}", e);
+            match event.event_type {
+                EventType::KeyPress(Key::MetaRight) => {
+                    let was = pressed_clone.swap(true, Ordering::SeqCst);
+                    if !was {
+                        let n = pc.fetch_add(1, Ordering::SeqCst) + 1;
+                        info!(
+                            "[Hotkey] 事件 #press={} 按下",
+                            n
+                        );
+                        if let Err(e) = sender.send(HotkeyEvent::Pressed) {
+                            error!("发送热键事件失败: {}", e);
+                        }
+                    }
                 }
-            } else if hotkey_release {
-                let n = rc.fetch_add(1, Ordering::SeqCst) + 1;
-                let was = pressed_clone.swap(false, Ordering::SeqCst);
-                info!(
-                    "[Hotkey] 事件 #release={} 松开（右侧 Alt）was_pressed={}",
-                    n, was
-                );
+                EventType::KeyRelease(Key::MetaRight) => {
+                    let was = pressed_clone.swap(false, Ordering::SeqCst);
+                    if was {
+                        let n = rc.fetch_add(1, Ordering::SeqCst) + 1;
+                        info!(
+                            "[Hotkey] 事件 #release={} 松开",
+                            n
+                        );
+                        if let Err(e) = sender.send(HotkeyEvent::Released) {
+                            error!("发送热键事件失败: {}", e);
+                        }
+                    }
+                }
+                _ => {}
             }
         });
 
@@ -208,20 +258,61 @@ pub fn check_input_monitoring_permission() -> bool {
     }
 }
 
-/// 提示用户手动授予 Accessibility 权限（不主动弹系统框）
+/// 请求 Accessibility 权限——触发 macOS 系统对话框
 pub fn request_accessibility_permission() {
+    #[cfg(target_os = "macos")]
+    {
+        use core_foundation::base::TCFType;
+        use core_foundation::boolean::CFBoolean;
+        use core_foundation::dictionary::CFDictionary;
+        use core_foundation::string::CFString;
+
+        extern "C" {
+            fn AXIsProcessTrustedWithOptions(
+                options: core_foundation::dictionary::CFDictionaryRef,
+            ) -> bool;
+        }
+
+        // kAXTrustedCheckOptionPrompt = true → 触发系统权限对话框
+        let key = CFString::new("AXTrustedCheckOptionPrompt");
+        let val = CFBoolean::true_value();
+        let options = CFDictionary::from_CFType_pairs(&[(key.as_CFType(), val.as_CFType())]);
+        unsafe {
+            AXIsProcessTrustedWithOptions(options.as_concrete_TypeRef());
+        }
+    }
+
     warn!("需要 Accessibility 权限才能监听全局热键");
     println!("⚠️  需要 Accessibility 权限");
     println!("请前往：系统设置 > 隐私与安全性 > 辅助功能");
     println!("将 Open Flow.app 添加到列表并启用，然后完全退出后重新打开应用。");
 }
 
-/// 提示用户手动授予 Input Monitoring 权限（不主动弹系统框）
+/// 请求 Input Monitoring 权限——触发 macOS 系统对话框
 pub fn request_input_monitoring_permission() {
+    #[cfg(target_os = "macos")]
+    {
+        #[link(name = "ApplicationServices", kind = "framework")]
+        unsafe extern "C" {
+            fn CGRequestListenEventAccess() -> bool;
+        }
+
+        unsafe {
+            CGRequestListenEventAccess();
+        }
+    }
+
     warn!("需要 Input Monitoring 权限才能监听全局热键");
     println!("⚠️  需要“输入监控”权限");
     println!("请前往：系统设置 > 隐私与安全性 > 输入监控");
     println!("将 Open Flow.app 添加到列表并启用，然后完全退出后重新打开应用。");
+}
+
+/// 请求麦克风权限
+pub fn request_microphone_permission() {
+    info!("麦克风权限尚未授权。首次录音时将弹出系统对话框。");
+    println!("   首次录音时将弹出麦克风权限对话框。");
+    println!("   如果没有弹出，请前往：系统设置 > 隐私与安全性 > 麦克风");
 }
 
 /// 检查麦克风权限状态。


### PR DESCRIPTION
## 概述

為 Open Flow 新增雲端語音辨識（Groq Whisper API）支援，以及可配置的熱鍵系統。

## 主要變更

- **AsrProvider 抽象層**：新增 trait 將語音辨識後端解耦，支援本地（SenseVoice ONNX）與雲端（Groq Whisper API）
- **Groq 雲端辨識**：透過 Groq API 使用 Whisper Large v3 / v3 Turbo 模型，支援 `GROQ_API_KEY` 環境變數或 config.toml 設定
- **Fn 鍵支援**：macOS 上透過 CGEventTap 偵測 Fn 鍵的 `0x800000` flag，可作為替代熱鍵
- **可配置熱鍵**：config.toml 新增 `hotkey` 欄位（`right_cmd` / `fn` / `f13`）
- **Hold / Toggle 模式**：新增 `trigger_mode` 欄位，`hold` = 按住錄音鬆開停止，`toggle` = 按一次開始再按停止
- **HotkeyEvent 擴展**：從 unit struct 改為 `Pressed` / `Released` enum

## Bug 修復

- 修復 `is_processing` 競態條件（toggle 模式下）
- 音訊回調中的 `Mutex::lock().unwrap()` 改為安全的 `if let Ok()`
- 多聲道麥克風音訊自動混音為單聲道（修復立體聲麥克風轉寫品質問題）
- Stale PID 檔案現在會驗證程序名稱，避免誤殺回收的 PID
- SIGKILL 後正確清理 PID 檔案
- Config 寫入改為原子操作（先寫暫存檔再 rename）
- 權限請求改為觸發 macOS 系統對話框（`AXIsProcessTrustedWithOptions` + `CGRequestListenEventAccess`）

## 新增 Config 欄位

```toml
provider = "local"                      # "local" 或 "groq"
groq_api_key = ""                       # 或設定 GROQ_API_KEY 環境變數
groq_model = "whisper-large-v3-turbo"   # 或 "whisper-large-v3"
groq_language = ""                      # 留空自動偵測，或 "en", "zh" 等
hotkey = "right_cmd"                    # "right_cmd", "fn", "f13"
trigger_mode = "toggle"                 # "toggle" 或 "hold"
```

所有新欄位都有 serde 預設值，與現有 config.toml 完全向後相容。

## 測試計畫

- [x] `cargo check` 通過
- [x] `cargo test` 全部通過（20 tests）
- [x] 測試本地辨識（SenseVoice）功能不受影響
- [x] 測試 Groq 辨識（需要 API key）
- [x] 測試 Fn 鍵觸發錄音
- [x] 測試 Hold 模式