### PR TITLE
feat: 新增浮動錄音指示器、CGEvent 打字注入、簡繁轉換

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1803,6 +1814,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2133,10 +2160,11 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open-flow"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "arboard",
+ "async-trait",
  "clap",
  "cocoa 0.25.0",
  "core-foundation 0.9.4",
@@ -2721,6 +2749,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -3502,6 +3531,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/lib.rs"
 # Core
 tokio = { version = "1.35", features = ["full"] }
 anyhow = "1.0"
+async-trait = "0.1"
 thiserror = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -49,7 +50,7 @@ rubato = "0.16"
 realfft = "3.4"
 
 # HTTP client (for model download)，用 rustls 避免 Linux 上依赖系统 OpenSSL
-reqwest = { version = "0.12", features = ["stream", "rustls-tls"], default-features = false }
+reqwest = { version = "0.12", features = ["stream", "rustls-tls", "multipart"], default-features = false }
 
 # Utils（放 [dependencies] 内，保证 Linux/macOS/Windows 都能用）
 uuid = { version = "1.6", features = ["v4"] }

--- a/src/asr/groq.rs
+++ b/src/asr/groq.rs
@@ -1,0 +1,139 @@
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use tracing::info;
+
+use super::AsrProvider;
+use crate::common::types::TranscriptionResult;
+
+pub struct GroqAsrProvider {
+    api_key: String,
+    model: String,
+    language: String,
+    client: reqwest::Client,
+}
+
+impl GroqAsrProvider {
+    pub fn new(api_key: String, model: String, language: String) -> Result<Self> {
+        if api_key.trim().is_empty() {
+            anyhow::bail!(
+                "Groq API key is required. Set GROQ_API_KEY env var or groq_api_key in config.toml"
+            );
+        }
+        Ok(Self {
+            api_key,
+            model,
+            language,
+            client: reqwest::Client::new(),
+        })
+    }
+}
+
+#[async_trait]
+impl AsrProvider for GroqAsrProvider {
+    async fn transcribe(&self, audio: &[f32], sample_rate: u32) -> Result<TranscriptionResult> {
+        let start = std::time::Instant::now();
+        info!(
+            "Groq transcription: {} samples @ {}Hz, model={}",
+            audio.len(),
+            sample_rate,
+            self.model
+        );
+
+        // Encode PCM f32 to WAV in memory
+        let wav_bytes = encode_wav(audio, sample_rate)?;
+
+        let file_part = reqwest::multipart::Part::bytes(wav_bytes)
+            .file_name("audio.wav")
+            .mime_str("audio/wav")?;
+
+        let mut form = reqwest::multipart::Form::new()
+            .text("model", self.model.clone())
+            .part("file", file_part);
+
+        if !self.language.is_empty() {
+            form = form.text("language", self.language.clone());
+        }
+
+        let res = self
+            .client
+            .post("https://api.groq.com/openai/v1/audio/transcriptions")
+            .bearer_auth(&self.api_key)
+            .multipart(form)
+            .timeout(std::time::Duration::from_secs(30))
+            .send()
+            .await
+            .context("Groq API request failed")?;
+
+        if !res.status().is_success() {
+            let status = res.status();
+            let body = res.text().await.unwrap_or_default();
+            return Err(anyhow!("Groq transcription failed: {} {}", status, body));
+        }
+
+        let body = res.text().await.context("Failed to read Groq response body")?;
+        let parsed: GroqTranscriptionResponse =
+            serde_json::from_str(&body).context("Failed to parse Groq response JSON")?;
+
+        let duration_ms = start.elapsed().as_millis() as u64;
+        info!(
+            "Groq transcription complete: {}ms, text length={}",
+            duration_ms,
+            parsed.text.len()
+        );
+
+        Ok(TranscriptionResult {
+            text: parsed.text,
+            confidence: 1.0,
+            language: if self.language.is_empty() {
+                None
+            } else {
+                Some(self.language.clone())
+            },
+            duration_ms,
+        })
+    }
+
+    fn check_status(&self) -> Result<String> {
+        if self.api_key.trim().is_empty() {
+            anyhow::bail!("Groq API key not configured")
+        }
+        Ok(format!("ready (model: {})", self.model))
+    }
+
+    fn name(&self) -> &str {
+        "groq (Whisper)"
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct GroqTranscriptionResponse {
+    text: String,
+}
+
+/// Encode f32 PCM samples to WAV bytes in memory.
+fn encode_wav(samples: &[f32], sample_rate: u32) -> Result<Vec<u8>> {
+    use std::io::Cursor;
+
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+
+    let mut cursor = Cursor::new(Vec::new());
+    {
+        let mut writer =
+            hound::WavWriter::new(&mut cursor, spec).context("Failed to create WAV writer")?;
+        for &s in samples {
+            let clamped = s.clamp(-1.0, 1.0);
+            let i16_val = (clamped * 32767.0) as i16;
+            writer
+                .write_sample(i16_val)
+                .context("Failed to write WAV sample")?;
+        }
+        writer.finalize().context("Failed to finalize WAV")?;
+    }
+
+    Ok(cursor.into_inner())
+}

--- a/src/asr/mod.rs
+++ b/src/asr/mod.rs
@@ -1,9 +1,12 @@
 pub mod decoder;
+pub mod groq;
 pub mod onnx_inference;
 pub mod preprocess;
 
 use anyhow::{Context, Result};
+use async_trait::async_trait;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tracing::{info, warn};
 
@@ -11,6 +14,26 @@ use crate::asr::decoder::CTCDecoder;
 use crate::asr::onnx_inference::OnnxInference;
 use crate::asr::preprocess::{AudioPreprocessor, TARGET_SAMPLE_RATE};
 use crate::common::types::TranscriptionResult;
+
+/// Trait abstracting speech recognition backends (local ONNX vs cloud API).
+#[async_trait]
+pub trait AsrProvider: Send + Sync {
+    /// Transcribe PCM audio samples. Returns transcribed text.
+    async fn transcribe(&self, audio: &[f32], sample_rate: u32) -> Result<TranscriptionResult>;
+
+    /// Optional warmup (e.g. load model, establish connection). Default no-op.
+    async fn warmup(&self) -> Result<()> {
+        Ok(())
+    }
+
+    /// Check provider readiness. Returns human-readable status string on success.
+    fn check_status(&self) -> Result<String> {
+        Ok("ready".into())
+    }
+
+    /// Provider name for display purposes.
+    fn name(&self) -> &str;
+}
 
 /// 调试与调参用环境变量（可开关）：
 /// - OPEN_FLOW_DEBUG_ASR: 打印 features shape、encoder_out_lens、logits 首/中/末帧 top-k 及 non_blank 帧数
@@ -319,6 +342,61 @@ pub struct AsrStatus {
     #[allow(dead_code)]
     pub tokens_exists: bool,
     pub ready: bool,
+}
+
+/// Local ASR provider wrapping the existing ONNX-based AsrEngine.
+/// Uses Arc<Mutex<>> so the engine can be moved into spawn_blocking.
+pub struct LocalAsrProvider {
+    engine: Arc<Mutex<AsrEngine>>,
+}
+
+impl LocalAsrProvider {
+    pub fn new(model_path: PathBuf) -> Self {
+        Self {
+            engine: Arc::new(Mutex::new(AsrEngine::new(model_path))),
+        }
+    }
+}
+
+#[async_trait]
+impl AsrProvider for LocalAsrProvider {
+    async fn transcribe(&self, audio: &[f32], sample_rate: u32) -> Result<TranscriptionResult> {
+        let audio = audio.to_vec();
+        let engine = self.engine.clone();
+        tokio::task::spawn_blocking(move || {
+            engine.lock().unwrap().transcribe_pcm(&audio, sample_rate)
+        })
+        .await
+        .context("spawn_blocking failed")?
+    }
+
+    async fn warmup(&self) -> Result<()> {
+        let engine = self.engine.clone();
+        tokio::task::spawn_blocking(move || {
+            engine.lock().unwrap().warmup();
+        })
+        .await
+        .context("warmup spawn_blocking failed")?;
+        Ok(())
+    }
+
+    fn check_status(&self) -> Result<String> {
+        let status = self.engine.lock().unwrap().check_status();
+        if status.ready {
+            Ok("ready".into())
+        } else {
+            anyhow::bail!(
+                "Model not ready: {:?} (onnx={}, model={})",
+                status.model_path,
+                status.onnx_exists,
+                status.model_exists
+            )
+        }
+    }
+
+    fn name(&self) -> &str {
+        "local (SenseVoice)"
+    }
 }
 
 #[cfg(test)]

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -230,13 +230,23 @@ impl AudioCapture {
             error!("❌ 音频采集错误: {}", err);
         };
 
+        let channels = self.channels as usize;
+
         let stream = match self.sample_format {
             SampleFormat::F32 => {
                 let buf = buffer.clone();
                 self.device.build_input_stream(
                     &self.config,
                     move |data: &[f32], _: &cpal::InputCallbackInfo| {
-                        buf.lock().unwrap().extend_from_slice(data);
+                        if let Ok(mut b) = buf.lock() {
+                            if channels > 1 {
+                                for chunk in data.chunks(channels) {
+                                    b.push(chunk.iter().sum::<f32>() / channels as f32);
+                                }
+                            } else {
+                                b.extend_from_slice(data);
+                            }
+                        }
                     },
                     err_fn,
                     None,
@@ -247,9 +257,15 @@ impl AudioCapture {
                 self.device.build_input_stream(
                     &self.config,
                     move |data: &[i16], _: &cpal::InputCallbackInfo| {
-                        let mut b = buf.lock().unwrap();
-                        for &s in data {
-                            b.push(s as f32 / 32768.0);
+                        if let Ok(mut b) = buf.lock() {
+                            if channels > 1 {
+                                for chunk in data.chunks(channels) {
+                                    let mixed = chunk.iter().map(|&s| s as f32 / 32768.0).sum::<f32>() / channels as f32;
+                                    b.push(mixed);
+                                }
+                            } else {
+                                b.extend(data.iter().map(|&s| s as f32 / 32768.0));
+                            }
                         }
                     },
                     err_fn,
@@ -261,9 +277,15 @@ impl AudioCapture {
                 self.device.build_input_stream(
                     &self.config,
                     move |data: &[u16], _: &cpal::InputCallbackInfo| {
-                        let mut b = buf.lock().unwrap();
-                        for &s in data {
-                            b.push((s as f32 - 32768.0) / 32768.0);
+                        if let Ok(mut b) = buf.lock() {
+                            if channels > 1 {
+                                for chunk in data.chunks(channels) {
+                                    let mixed = chunk.iter().map(|&s| (s as f32 - 32768.0) / 32768.0).sum::<f32>() / channels as f32;
+                                    b.push(mixed);
+                                }
+                            } else {
+                                b.extend(data.iter().map(|&s| (s as f32 - 32768.0) / 32768.0));
+                            }
                         }
                     },
                     err_fn,

--- a/src/cli/daemon.rs
+++ b/src/cli/daemon.rs
@@ -5,6 +5,8 @@ use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+use crate::asr::groq::GroqAsrProvider;
+use crate::asr::{AsrProvider, LocalAsrProvider};
 use crate::common::config::Config;
 use crate::daemon::run_daemon;
 use crate::tray::{TrayIconState, TrayState};
@@ -35,7 +37,18 @@ fn read_pid() -> Option<u32> {
 fn is_running(pid: u32) -> bool {
     #[cfg(unix)]
     {
-        unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+        if unsafe { libc::kill(pid as libc::pid_t, 0) } != 0 {
+            return false;
+        }
+        // 验证是否确实是 open-flow 进程，而不是被回收的 PID
+        if let Ok(output) = std::process::Command::new("ps")
+            .args(["-p", &pid.to_string(), "-o", "comm="])
+            .output()
+        {
+            let comm = String::from_utf8_lossy(&output.stdout);
+            return comm.trim().contains("open-flow");
+        }
+        true // ps 失败则假定是我们的进程
     }
     #[cfg(windows)]
     {
@@ -177,20 +190,40 @@ pub fn start_foreground(model: Option<PathBuf>) -> anyhow::Result<()> {
         }
     };
 
+    // ── 构建 ASR provider ──────────────────────────────────────────
+    let config = Config::load().unwrap_or_default();
+    let provider: Arc<dyn AsrProvider> = match config.provider.as_str() {
+        "groq" => {
+            let api_key = config.resolved_groq_api_key();
+            match GroqAsrProvider::new(api_key, config.groq_model.clone(), config.groq_language.clone()) {
+                Ok(p) => {
+                    println!("   Provider: Groq ({})", config.groq_model);
+                    Arc::new(p)
+                }
+                Err(e) => {
+                    eprintln!("⚠️  Groq provider 初始化失败: {}。回退到本地模式。", e);
+                    Arc::new(LocalAsrProvider::new(model_path.clone()))
+                }
+            }
+        }
+        _ => {
+            println!("   Provider: Local (SenseVoice)");
+            Arc::new(LocalAsrProvider::new(model_path.clone()))
+        }
+    };
+
     // ── 在专用线程运行 daemon（current_thread 运行时，Daemon 含 cpal::Stream 非 Send）
     let log = log_path()?;
     println!("✅ Open Flow 已启动 (PID: {})", my_pid);
-    println!("   模型: {:?}", model_path);
-    #[cfg(target_os = "macos")]
-    println!("   热键: 右 Command（固定）");
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
-    println!("   热键: 右侧 Alt 键（固定）");
-    #[cfg(all(not(target_os = "macos"), not(target_os = "windows"), not(target_os = "linux")))]
-    println!("   热键: 右 Meta/Super（固定）");
+    println!("   热键: {}", config.hotkey);
+    println!("   触发模式: {}", config.trigger_mode);
     println!("   日志: {}", log.display());
     println!();
     println!("   按 Ctrl+C 或托盘菜单「退出」可停止");
     println!("   ⏳ 模型加载与预热约需 3-5 秒，完成后热键即可使用");
+
+    let daemon_alive = Arc::new(AtomicBool::new(true));
+    let daemon_alive_clone = daemon_alive.clone();
 
     let daemon_handle = std::thread::spawn(move || {
         let rt = tokio::runtime::Builder::new_current_thread()
@@ -198,14 +231,15 @@ pub fn start_foreground(model: Option<PathBuf>) -> anyhow::Result<()> {
             .build()
             .expect("daemon tokio runtime");
         rt.block_on(async {
-            if let Err(e) = run_daemon(model_path, tray_handle).await {
+            if let Err(e) = run_daemon(provider, tray_handle).await {
                 eprintln!("Daemon 错误: {}", e);
             }
         });
+        daemon_alive_clone.store(false, Ordering::SeqCst);
     });
 
     // ── 主线程：驱动 macOS NSRunLoop，让托盘 / 菜单事件得以分发 ──────
-    run_main_loop(tray.as_ref());
+    run_main_loop(tray.as_ref(), &daemon_alive);
 
     // ── 退出前显式隐藏菜单栏图标并 pump run loop，避免图标残留
     if let Some(ref t) = tray {
@@ -219,14 +253,28 @@ pub fn start_foreground(model: Option<PathBuf>) -> anyhow::Result<()> {
 
     // ── 退出清理 ──────────────────────────────────────────────────────
     remove_pid_file();
-    let _ = daemon_handle.join();
+
+    // 给 daemon 线程短时间优雅退出
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+    while std::time::Instant::now() < deadline {
+        if daemon_handle.is_finished() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
     println!("\n👋 Open Flow 已停止");
-    Ok(())
+
+    // 强制退出——daemon 线程可能阻塞在 tokio recv() 或 CFRunLoop 上
+    std::process::exit(0);
 }
 
 /// macOS 主循环：每 100ms 执行一次 NSRunLoop，检查是否需要退出。
 /// 这是让 tray-icon 在 macOS 上正常渲染和响应菜单的关键。
-fn run_main_loop(tray: Option<&TrayState>) {
+fn run_main_loop(
+    tray: Option<&TrayState>,
+    daemon_alive: &AtomicBool,
+) {
     loop {
         // 应用 daemon 发来的托盘状态更新（灰/红/黄）
         if let Some(t) = tray {
@@ -255,6 +303,11 @@ fn run_main_loop(tray: Option<&TrayState>) {
         // SIGTERM / SIGINT（open-flow stop 或 Ctrl+C）
         if SIGNAL_SHUTDOWN.load(Ordering::SeqCst) {
             tracing::info!("收到信号，正常退出");
+            break;
+        }
+        // daemon 线程意外退出
+        if !daemon_alive.load(Ordering::SeqCst) {
+            tracing::error!("Daemon 线程已意外退出");
             break;
         }
     }
@@ -299,8 +352,8 @@ fn prepare_appkit() {
 
         static INIT: std::sync::Once = std::sync::Once::new();
         INIT.call_once(|| {
-            // NSApplicationActivationPolicyRegular = 0
-            let _: () = msg_send![app, setActivationPolicy: 0i64];
+            // NSApplicationActivationPolicyAccessory = 1（无 Dock 图标，但可以有窗口）
+            let _: () = msg_send![app, setActivationPolicy: 1i64];
             let _: () = msg_send![app, finishLaunching];
         });
     }
@@ -383,6 +436,9 @@ pub async fn stop() -> Result<()> {
             }
         }
         unsafe { libc::kill(pid as libc::pid_t, libc::SIGKILL) };
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        remove_pid_file();
+        println!("✅ daemon 已停止（强制终止）");
     }
 
     #[cfg(windows)]
@@ -414,17 +470,14 @@ pub async fn status() -> Result<()> {
         Some(pid) if is_running(pid) => {
             let uptime = get_uptime_str(pid);
             println!("Open Flow daemon 状态");
-            println!("  状态:   ✅ 运行中");
-            println!("  PID:    {}", pid);
-            println!("  运行:   {}", uptime);
-            println!("  模型:   {:?}", config.model_path.unwrap_or_default());
-            #[cfg(target_os = "macos")]
-            println!("  热键:   右 Command（固定）");
-            #[cfg(any(target_os = "windows", target_os = "linux"))]
-            println!("  热键:   右侧 Alt 键（固定）");
-            #[cfg(all(not(target_os = "macos"), not(target_os = "windows"), not(target_os = "linux")))]
-            println!("  热键:   右 Meta/Super（固定）");
-            println!("  日志:   {}", log_path()?.display());
+            println!("  状态:     ✅ 运行中");
+            println!("  PID:      {}", pid);
+            println!("  运行:     {}", uptime);
+            println!("  模型:     {:?}", config.model_path.unwrap_or_default());
+            println!("  Provider: {}", config.provider);
+            println!("  热键:     {}", config.hotkey);
+            println!("  触发模式: {}", config.trigger_mode);
+            println!("  日志:     {}", log_path()?.display());
         }
         Some(pid) => {
             println!("Open Flow daemon 状态");

--- a/src/cli/daemon.rs
+++ b/src/cli/daemon.rs
@@ -178,17 +178,30 @@ pub fn start_foreground(model: Option<PathBuf>) -> anyhow::Result<()> {
     }
 
     // ── 在主线程创建托盘（macOS 菜单栏 / Windows·Linux 系统托盘）────────────────────
-    let (mut tray, tray_handle) = match TrayState::new() {
+    let (mut tray, mut tray_handle_raw) = match TrayState::new() {
         Ok((t, h)) => {
             t.set_state(TrayIconState::Idle);
             tracing::info!("✅ 托盘图标已创建");
-            (Some(t), Some(Arc::new(h)))
+            (Some(t), Some(h))
         }
         Err(e) => {
             tracing::warn!("托盘图标创建失败: {}，继续运行（无托盘）", e);
             (None, None)
         }
     };
+
+    // ── 创建浮动指示器（overlay）──────────────────────────────────────
+    use crate::overlay::OverlayWindow;
+    let overlay = OverlayWindow::new();
+    let (overlay_tx, overlay_rx) = std::sync::mpsc::sync_channel::<TrayIconState>(16);
+    // 在包装为 Arc 之前设置 overlay sender
+    if let Some(ref mut handle) = tray_handle_raw {
+        handle.set_overlay_sender(overlay_tx);
+    }
+    let tray_handle = tray_handle_raw.map(Arc::new);
+    if overlay.is_some() {
+        tracing::info!("✅ 浮动指示器已创建");
+    }
 
     // ── 构建 ASR provider ──────────────────────────────────────────
     let config = Config::load().unwrap_or_default();
@@ -239,7 +252,7 @@ pub fn start_foreground(model: Option<PathBuf>) -> anyhow::Result<()> {
     });
 
     // ── 主线程：驱动 macOS NSRunLoop，让托盘 / 菜单事件得以分发 ──────
-    run_main_loop(tray.as_ref(), &daemon_alive);
+    run_main_loop(tray.as_ref(), overlay.as_ref(), &overlay_rx, &daemon_alive);
 
     // ── 退出前显式隐藏菜单栏图标并 pump run loop，避免图标残留
     if let Some(ref t) = tray {
@@ -273,6 +286,8 @@ pub fn start_foreground(model: Option<PathBuf>) -> anyhow::Result<()> {
 /// 这是让 tray-icon 在 macOS 上正常渲染和响应菜单的关键。
 fn run_main_loop(
     tray: Option<&TrayState>,
+    overlay: Option<&crate::overlay::OverlayWindow>,
+    overlay_rx: &std::sync::mpsc::Receiver<TrayIconState>,
     daemon_alive: &AtomicBool,
 ) {
     loop {
@@ -282,17 +297,18 @@ fn run_main_loop(
             t.flush_menu_events();
         }
 
+        // 应用 overlay 状态更新
+        while let Ok(state) = overlay_rx.try_recv() {
+            if let Some(o) = overlay {
+                o.update_state(state);
+            }
+        }
+
         // 驱动平台事件循环：macOS NSRunLoop；Windows Win32；Linux glib
         #[cfg(target_os = "macos")]
         pump_run_loop_100ms();
 
-        #[cfg(target_os = "windows")]
-        pump_win32_messages();
-
-        #[cfg(target_os = "linux")]
-        pump_glib_linux();
-
-        #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+        #[cfg(not(target_os = "macos"))]
         std::thread::sleep(std::time::Duration::from_millis(100));
 
         // 托盘菜单「退出」
@@ -309,32 +325,6 @@ fn run_main_loop(
         if !daemon_alive.load(Ordering::SeqCst) {
             tracing::error!("Daemon 线程已意外退出");
             break;
-        }
-    }
-}
-
-/// Linux：处理 glib 主上下文，使托盘图标和菜单能响应点击。
-#[cfg(target_os = "linux")]
-fn pump_glib_linux() {
-    let ctx = glib::MainContext::default();
-    while ctx.iteration(false) {}
-}
-
-/// Windows：处理当前线程消息队列，使托盘图标和菜单能响应点击。
-#[cfg(target_os = "windows")]
-fn pump_win32_messages() {
-    use windows_sys::Win32::UI::WindowsAndMessaging::{
-        DispatchMessageW, PeekMessageW, TranslateMessage, MSG, PM_REMOVE, WM_QUIT,
-    };
-
-    let mut msg = MSG::default();
-    while unsafe { PeekMessageW(&mut msg, None, 0, 0, PM_REMOVE) }.as_bool() {
-        if msg.message == WM_QUIT {
-            break;
-        }
-        unsafe {
-            TranslateMessage(&msg);
-            DispatchMessageW(&msg);
         }
     }
 }

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -10,17 +10,59 @@ const CONFIG_FILE: &str = "config.toml";
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     pub model_path: Option<PathBuf>,
+    /// "local" or "groq"
+    #[serde(default = "default_provider")]
+    pub provider: String,
+    /// Groq API key (env var GROQ_API_KEY takes precedence)
+    #[serde(default)]
+    pub groq_api_key: String,
+    /// Groq Whisper model name
+    #[serde(default = "default_groq_model")]
+    pub groq_model: String,
+    /// Optional language hint for Groq (e.g. "en", "zh"). Empty = auto-detect.
+    #[serde(default)]
+    pub groq_language: String,
+    /// Hotkey identifier: "right_cmd", "fn", "f13", etc.
+    #[serde(default = "default_hotkey")]
+    pub hotkey: String,
+    /// Trigger mode: "toggle" or "hold"
+    #[serde(default = "default_trigger_mode")]
+    pub trigger_mode: String,
+}
+
+fn default_provider() -> String {
+    "local".into()
+}
+fn default_groq_model() -> String {
+    "whisper-large-v3-turbo".into()
+}
+fn default_hotkey() -> String {
+    "right_cmd".into()
+}
+fn default_trigger_mode() -> String {
+    "toggle".into()
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             model_path: None,
+            provider: default_provider(),
+            groq_api_key: String::new(),
+            groq_model: default_groq_model(),
+            groq_language: String::new(),
+            hotkey: default_hotkey(),
+            trigger_mode: default_trigger_mode(),
         }
     }
 }
 
 impl Config {
+    /// Returns Groq API key: env var GROQ_API_KEY takes precedence over config file.
+    pub fn resolved_groq_api_key(&self) -> String {
+        std::env::var("GROQ_API_KEY").unwrap_or_else(|_| self.groq_api_key.clone())
+    }
+
     pub fn load() -> Result<Self> {
         let config_path = Self::config_path()?;
 
@@ -43,13 +85,19 @@ impl Config {
             }
         }
 
+        if config.model_path.as_ref().map_or(false, |p| p.as_os_str().is_empty()) {
+            config.model_path = None;
+        }
+
         Ok(config)
     }
 
     pub fn save(&self) -> Result<()> {
         let config_path = Self::config_path()?;
         let content = toml::to_string_pretty(self)?;
-        fs::write(config_path, content)?;
+        let tmp = config_path.with_extension("toml.tmp");
+        fs::write(&tmp, &content)?;
+        fs::rename(&tmp, &config_path)?;
         Ok(())
     }
 

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -28,6 +28,9 @@ pub struct Config {
     /// Trigger mode: "toggle" or "hold"
     #[serde(default = "default_trigger_mode")]
     pub trigger_mode: String,
+    /// Convert simplified Chinese to traditional: "none", "s2t" (simplified->traditional), "t2s" (traditional->simplified)
+    #[serde(default)]
+    pub chinese_conversion: String,
 }
 
 fn default_provider() -> String {
@@ -53,6 +56,7 @@ impl Default for Config {
             groq_language: String::new(),
             hotkey: default_hotkey(),
             trigger_mode: default_trigger_mode(),
+            chinese_conversion: String::new(),
         }
     }
 }

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -16,4 +16,7 @@ pub struct TranscriptionResult {
 
 /// 热键触发事件（右 Command 按下）
 #[derive(Debug, Clone)]
-pub struct HotkeyEvent;
+pub enum HotkeyEvent {
+    Pressed,
+    Released,
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1,11 +1,10 @@
 use anyhow::{Context, Result};
-use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
-use tracing::{info, warn};
+use tracing::info;
 
-use crate::asr::AsrEngine;
+use crate::asr::AsrProvider;
 use crate::audio::AudioCapture;
 use crate::common::types::{HotkeyEvent, RecordingState};
 use crate::hotkey::{
@@ -29,9 +28,8 @@ pub struct Daemon {
     is_processing: AtomicBool,
     /// 已收到的热键事件次数（用于日志：第 N 次按键）
     hotkey_recv_count: std::sync::atomic::AtomicU64,
-    model_path: PathBuf,
     audio_capture: AudioCapture,
-    asr_engine: Arc<Mutex<AsrEngine>>,
+    provider: Arc<dyn AsrProvider>,
     text_injector: TextInjector,
     /// 当前录音流（Some = 正在录音，drop 即停止）
     active_stream: Mutex<Option<cpal::Stream>>,
@@ -39,28 +37,30 @@ pub struct Daemon {
     recording_buffer: Mutex<Arc<Mutex<Vec<f32>>>>,
     /// 托盘句柄（Send+Sync，状态更新发回主线程）
     tray: Option<Arc<TrayHandle>>,
+    /// 触发模式: "toggle" or "hold"
+    trigger_mode: String,
 }
 
 impl Daemon {
     pub fn new(
-        model_path: PathBuf,
+        provider: Arc<dyn AsrProvider>,
         tray: Option<Arc<TrayHandle>>,
     ) -> Result<Self> {
         let audio_capture = AudioCapture::new().context("初始化音频采集器失败")?;
-        let asr_engine = Arc::new(Mutex::new(AsrEngine::new(model_path.clone())));
         let text_injector = TextInjector::new();
+        let config = crate::common::config::Config::load().unwrap_or_default();
 
         Ok(Self {
             state: Arc::new(Mutex::new(RecordingState::default())),
             is_processing: AtomicBool::new(false),
             hotkey_recv_count: std::sync::atomic::AtomicU64::new(0),
-            model_path,
             audio_capture,
-            asr_engine,
+            provider,
             text_injector,
             active_stream: Mutex::new(None),
             recording_buffer: Mutex::new(Arc::new(Mutex::new(Vec::new()))),
             tray,
+            trigger_mode: config.trigger_mode,
         })
     }
 
@@ -81,54 +81,50 @@ impl Daemon {
         println!("   Accessibility: {}", accessibility_ok);
         println!("   Input Monitoring: {}", input_monitoring_ok);
         println!("   Microphone: {}", microphone_ok);
-        if !microphone_ok {
-            println!();
-            println!("⚠️  缺少麦克风权限！录音将为静音，无法转写。");
-            println!("   请前往：系统设置 > 隐私与安全性 > 麦克风");
-            println!("   将 Open Flow.app 添加并启用，然后完全退出并重新打开。");
-        }
 
-        // ── Accessibility 权限检查 ───────────────────────────────────
+        // 请求缺失的权限（触发系统对话框）
         if !accessibility_ok {
-            warn!("Accessibility 权限检查失败，可能是 TCC 将当前可执行文件识别为新身份");
-            request_accessibility_permission();
             println!();
-            println!("授权后请完全退出并重新打开 Open Flow。");
-            anyhow::bail!("缺少 Accessibility 权限");
+            println!("⚠️  Accessibility 权限未授权——正在请求...");
+            request_accessibility_permission();
         }
         if !input_monitoring_ok {
-            warn!("Input Monitoring 权限检查失败，可能是 TCC 将当前可执行文件识别为新身份");
-            crate::hotkey::request_input_monitoring_permission();
             println!();
-            println!("授权后请完全退出并重新打开 Open Flow。");
-            anyhow::bail!("缺少 Input Monitoring 权限");
+            println!("⚠️  Input Monitoring 权限未授权——正在请求...");
+            crate::hotkey::request_input_monitoring_permission();
+        }
+        if !microphone_ok {
+            println!();
+            println!("⚠️  麦克风权限尚未授权。");
+            crate::hotkey::request_microphone_permission();
         }
 
-        // ── ASR 状态 ─────────────────────────────────────────────────
-        let asr_status = self.asr_engine.lock().unwrap().check_status();
-        if !asr_status.ready {
-            anyhow::bail!(
-                "模型未就绪：{:?}\n  onnx={} mvn={}",
-                asr_status.model_path,
-                asr_status.onnx_exists,
-                asr_status.model_exists,
-            );
+        if !accessibility_ok || !input_monitoring_ok {
+            println!();
+            println!("⏳ 等待权限授权... 请在系统设置中授权，然后应用将重试。");
+            println!("   （如果授权后热键不工作，请重启应用）");
         }
 
-        // ── 模型预热（消除首次推理 JIT 开销）──────────────────────────
+        // ── Provider 状态检查 ──────────────────────────────────────────
+        if let Err(e) = self.provider.check_status() {
+            anyhow::bail!("Provider 未就绪: {}", e);
+        }
+
+        // ── Provider 预热（消除首次推理 JIT 开销）──────────────────────
         {
             let warmup_start = std::time::Instant::now();
-            self.asr_engine.lock().unwrap().warmup();
+            self.provider.warmup().await?;
             let warmup_ms = warmup_start.elapsed().as_millis();
-            info!("模型预热耗时: {}ms", warmup_ms);
+            info!("Provider 预热耗时: {}ms", warmup_ms);
         }
 
         // ── 音频设备信息 ──────────────────────────────────────────────
         let audio_info = self.audio_capture.get_info();
 
         // ── 启动热键监听器 ─────────────────────────────────────────────
+        let config = crate::common::config::Config::load().unwrap_or_default();
         let (hotkey_tx, hotkey_rx) = std::sync::mpsc::channel();
-        let listener = HotkeyListener::new(hotkey_tx);
+        let listener = HotkeyListener::new(hotkey_tx, config.hotkey.clone());
         listener.start().context("启动热键监听器失败")?;
 
         // ── 把同步 mpsc 桥接到 tokio mpsc ─────────────────────────────
@@ -159,9 +155,9 @@ impl Daemon {
             "   音频设备: {}Hz / {} 通道",
             audio_info.sample_rate, audio_info.channels
         );
-        println!("   模型路径: {:?}", self.model_path);
+        println!("   Provider: {}", self.provider.name());
         println!();
-        println!("🎙️  按右侧 Command 键开始录音，再按一次停止并转写");
+        println!("🎙️  按热键开始录音，再按一次停止并转写");
         println!("   托盘图标可查看状态（灰=待机 红=录音 黄=转写）");
         println!();
 
@@ -174,11 +170,10 @@ impl Daemon {
                             self.handle_hotkey(ev, &event_tx).await;
                         }
                         DaemonEvent::TranscriptionComplete(text) => {
+                            self.is_processing.store(false, Ordering::SeqCst);
                             self.set_tray(TrayIconState::Idle);
                             println!("📝 转写完成: {}", text);
-                            // 延迟 250ms 再粘贴，避免与用户紧接着的「第三次按键」重叠：
-                            // inject 模拟左 Command+V 会干扰 CGEventTap，导致右 Command 的 KeyPress 丢失、只收到 Release
-                            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
                             info!("[Hotkey] 开始粘贴");
                             if let Err(e) = self.text_injector.inject(&text).await {
                                 eprintln!("⚠️  文字注入失败: {e}");
@@ -210,32 +205,61 @@ impl Daemon {
         }
     }
 
-    async fn handle_hotkey(&self, _event: HotkeyEvent, tx: &mpsc::Sender<DaemonEvent>) {
+    async fn handle_hotkey(&self, event: HotkeyEvent, tx: &mpsc::Sender<DaemonEvent>) {
         let n = self.hotkey_recv_count.fetch_add(1, Ordering::SeqCst) + 1;
         let is_processing = self.is_processing.load(Ordering::SeqCst);
         let is_recording = self.state.lock().unwrap().is_recording;
         info!(
-            "[Hotkey] 收到第 {} 次按键 is_recording={} is_processing={}",
-            n, is_recording, is_processing
+            "[Hotkey] 收到第 {} 次按键 event={:?} is_recording={} is_processing={} mode={}",
+            n, event, is_recording, is_processing, self.trigger_mode
         );
-        if is_processing {
-            info!("[Hotkey] 第 {} 次 -> 忽略（转写中）", n);
-            return;
-        }
-        if is_recording {
-            info!("[Hotkey] 第 {} 次 -> 动作: 停止录音并转写", n);
-            self.set_tray(TrayIconState::Transcribing);
-            let res = self.stop_and_transcribe(tx).await;
-            if let Err(e) = res {
-                self.set_tray(TrayIconState::Idle);
-                eprintln!("⚠️  转写失败: {e}");
+
+        match event {
+            HotkeyEvent::Pressed => {
+                if is_processing {
+                    info!("[Hotkey] 第 {} 次 -> 忽略（转写中）", n);
+                    return;
+                }
+                if self.trigger_mode == "hold" {
+                    // Hold 模式: Pressed 始终开始录音
+                    if !is_recording {
+                        info!("[Hotkey] 第 {} 次 -> 动作: 开始录音（hold 模式）", n);
+                        if let Err(e) = self.start_recording() {
+                            eprintln!("⚠️  录音启动失败: {e}");
+                        } else {
+                            self.set_tray(TrayIconState::Recording);
+                        }
+                    }
+                } else {
+                    // Toggle 模式: Pressed 切换状态
+                    if is_recording {
+                        info!("[Hotkey] 第 {} 次 -> 动作: 停止录音并转写（toggle 模式）", n);
+                        self.set_tray(TrayIconState::Transcribing);
+                        if let Err(e) = self.stop_and_transcribe(tx).await {
+                            self.set_tray(TrayIconState::Idle);
+                            eprintln!("⚠️  转写失败: {e}");
+                        }
+                    } else {
+                        info!("[Hotkey] 第 {} 次 -> 动作: 开始录音（toggle 模式）", n);
+                        if let Err(e) = self.start_recording() {
+                            eprintln!("⚠️  录音启动失败: {e}");
+                        } else {
+                            self.set_tray(TrayIconState::Recording);
+                        }
+                    }
+                }
             }
-        } else {
-            info!("[Hotkey] 第 {} 次 -> 动作: 开始录音", n);
-            if let Err(e) = self.start_recording() {
-                eprintln!("⚠️  录音启动失败: {e}");
-            } else {
-                self.set_tray(TrayIconState::Recording);
+            HotkeyEvent::Released => {
+                if self.trigger_mode == "hold" && is_recording {
+                    // Hold 模式: Released 始终停止
+                    info!("[Hotkey] 第 {} 次 -> 动作: 停止录音并转写（hold 松开）", n);
+                    self.set_tray(TrayIconState::Transcribing);
+                    if let Err(e) = self.stop_and_transcribe(tx).await {
+                        self.set_tray(TrayIconState::Idle);
+                        eprintln!("⚠️  转写失败: {e}");
+                    }
+                }
+                // Toggle 模式: Released 忽略
             }
         }
     }
@@ -259,7 +283,7 @@ impl Daemon {
         state.start_time = Some(std::time::Instant::now());
 
         info!("[Hotkey] 录音已启动");
-        println!("🔴 录音中... 再按右侧 Command 键停止");
+        println!("🔴 录音中... 再按热键停止");
         Ok(())
     }
 
@@ -313,23 +337,21 @@ impl Daemon {
             return Ok(());
         }
 
-        // 直接把内存中的 PCM 数据送给 ASR，不经过磁盘文件
+        // 通过 AsrProvider trait 进行转写（本地或云端）
         let sample_rate = self.audio_capture.get_info().sample_rate;
-        let asr_engine = self.asr_engine.clone();
-        let infer_fut = tokio::task::spawn_blocking(move || {
-            asr_engine
-                .lock()
-                .unwrap()
-                .transcribe_pcm(&buffer, sample_rate)
-        });
+        let provider = self.provider.clone();
 
-        let join_result = match tokio::time::timeout(
+        let result = match tokio::time::timeout(
             std::time::Duration::from_secs(30),
-            infer_fut,
+            provider.transcribe(&buffer, sample_rate),
         )
         .await
         {
-            Ok(r) => r,
+            Ok(Ok(r)) => r,
+            Ok(Err(e)) => {
+                self.is_processing.store(false, Ordering::SeqCst);
+                return Err(e);
+            }
             Err(_elapsed) => {
                 self.is_processing.store(false, Ordering::SeqCst);
                 eprintln!("⚠️  转写超时（>30s），已放弃，请检查模型或重启 daemon");
@@ -337,23 +359,6 @@ impl Daemon {
             }
         };
 
-        let result = match join_result {
-            Ok(r) => r,
-            Err(e) => {
-                self.is_processing.store(false, Ordering::SeqCst);
-                return Err(anyhow::anyhow!("spawn_blocking failed: {}", e));
-            }
-        };
-        let result = match result {
-            Ok(r) => r,
-            Err(e) => {
-                self.is_processing.store(false, Ordering::SeqCst);
-                return Err(e);
-            }
-        };
-
-        // 在发送前清除，避免：Hotkey(P3) 先于 TranscriptionComplete 被处理时被误忽略
-        self.is_processing.store(false, Ordering::SeqCst);
         tx.send(DaemonEvent::TranscriptionComplete(result.text))
             .await
             .ok();
@@ -363,9 +368,9 @@ impl Daemon {
 }
 
 pub async fn run_daemon(
-    model_path: PathBuf,
+    provider: Arc<dyn AsrProvider>,
     tray: Option<Arc<TrayHandle>>,
 ) -> Result<()> {
-    let daemon = Daemon::new(model_path, tray)?;
+    let daemon = Daemon::new(provider, tray)?;
     daemon.run().await
 }

--- a/src/hotkey/mod.rs
+++ b/src/hotkey/mod.rs
@@ -9,19 +9,21 @@ use crate::common::types::HotkeyEvent;
 /// 热键监听器，通过 rdev（底层 CGEventTap）监听全局按键事件
 pub struct HotkeyListener {
     sender: Sender<HotkeyEvent>,
+    hotkey: String,
 }
 
 impl HotkeyListener {
-    pub fn new(sender: Sender<HotkeyEvent>) -> Self {
-        Self { sender }
+    pub fn new(sender: Sender<HotkeyEvent>, hotkey: String) -> Self {
+        Self { sender, hotkey }
     }
 
     /// 在独立线程启动热键监听
     pub fn start(self) -> Result<()> {
-        info!("正在启动热键监听器（右侧 Command 键，基于 CGEventTap）...");
+        info!("正在启动热键监听器（热键: {}）...", self.hotkey);
 
+        let hotkey = self.hotkey.clone();
         thread::spawn(move || {
-            if let Err(e) = Self::run_listen_loop(self.sender) {
+            if let Err(e) = Self::run_listen_loop(self.sender, &hotkey) {
                 error!("热键监听错误: {}", e);
             }
         });
@@ -29,27 +31,28 @@ impl HotkeyListener {
         Ok(())
     }
 
-    fn run_listen_loop(sender: Sender<HotkeyEvent>) -> Result<()> {
+    fn run_listen_loop(sender: Sender<HotkeyEvent>, hotkey: &str) -> Result<()> {
         #[cfg(target_os = "macos")]
         {
-            return Self::run_listen_loop_macos(sender);
+            return Self::run_listen_loop_macos(sender, hotkey);
         }
 
         #[cfg(not(target_os = "macos"))]
         {
-            return Self::run_listen_loop_rdev(sender);
+            return Self::run_listen_loop_rdev(sender, hotkey);
         }
     }
 
     #[cfg(target_os = "macos")]
-    fn run_listen_loop_macos(sender: Sender<HotkeyEvent>) -> Result<()> {
+    fn run_listen_loop_macos(sender: Sender<HotkeyEvent>, hotkey: &str) -> Result<()> {
         use core_foundation::runloop::{kCFRunLoopCommonModes, CFRunLoop};
         use core_graphics::event::{
-            CGEventFlags, CGEventTap, CGEventTapLocation, CGEventTapOptions, CGEventType, EventField,
-            KeyCode,
+            CGEventFlags, CGEventTap, CGEventTapLocation, CGEventTapOptions, CGEventType,
+            EventField, KeyCode,
         };
         use std::sync::atomic::{AtomicBool, AtomicU64};
 
+        let is_fn_key = hotkey == "fn";
         let pressed = Arc::new(AtomicBool::new(false));
         let pressed_clone = pressed.clone();
         let press_count = Arc::new(AtomicU64::new(0));
@@ -57,7 +60,12 @@ impl HotkeyListener {
         let pc = press_count.clone();
         let rc = release_count.clone();
 
-        println!("⌨️  热键监听器已启动（CGEventTap）");
+        let key_name = if is_fn_key {
+            "Fn"
+        } else {
+            "右侧 Command"
+        };
+        println!("⌨️  热键监听器已启动（CGEventTap，热键: {}）", key_name);
 
         let current = CFRunLoop::get_current();
         let tap = CGEventTap::new(
@@ -70,33 +78,66 @@ impl HotkeyListener {
                     return None;
                 }
 
-                let keycode =
-                    event.get_integer_value_field(EventField::KEYBOARD_EVENT_KEYCODE) as u16;
-                if keycode != KeyCode::RIGHT_COMMAND {
-                    return None;
-                }
+                if is_fn_key {
+                    // Fn key: detect via secondary Fn flag (0x800000)
+                    let flags = event.get_flags();
+                    let fn_down = (flags.bits() & 0x800000) != 0;
 
-                let is_pressed = event.get_flags().contains(CGEventFlags::CGEventFlagCommand);
-                if is_pressed {
-                    let was = pressed_clone.swap(true, Ordering::SeqCst);
-                    if !was {
-                        let n = pc.fetch_add(1, Ordering::SeqCst) + 1;
+                    if fn_down {
+                        let was = pressed_clone.swap(true, Ordering::SeqCst);
+                        if !was {
+                            let n = pc.fetch_add(1, Ordering::SeqCst) + 1;
+                            info!(
+                                "[Hotkey] 事件 #press={} 按下（Fn）",
+                                n
+                            );
+                            if let Err(e) = sender.send(HotkeyEvent::Pressed) {
+                                error!("发送热键事件失败: {}", e);
+                            }
+                        }
+                    } else if pressed_clone.load(Ordering::SeqCst) {
+                        pressed_clone.store(false, Ordering::SeqCst);
+                        let n = rc.fetch_add(1, Ordering::SeqCst) + 1;
                         info!(
-                            "[Hotkey] 事件 #press={} 按下（右侧 Command）was_pressed={} -> 发送",
-                            n, was
+                            "[Hotkey] 事件 #release={} 松开（Fn）",
+                            n
                         );
-                        if let Err(e) = sender.send(HotkeyEvent) {
+                        if let Err(e) = sender.send(HotkeyEvent::Released) {
                             error!("发送热键事件失败: {}", e);
                         }
                     }
                 } else {
-                    let was = pressed_clone.swap(false, Ordering::SeqCst);
-                    if was {
-                        let n = rc.fetch_add(1, Ordering::SeqCst) + 1;
-                        info!(
-                            "[Hotkey] 事件 #release={} 松开（右侧 Command）was_pressed={}",
-                            n, was
-                        );
+                    let keycode =
+                        event.get_integer_value_field(EventField::KEYBOARD_EVENT_KEYCODE) as u16;
+                    if keycode != KeyCode::RIGHT_COMMAND {
+                        return None;
+                    }
+
+                    let is_pressed = event.get_flags().contains(CGEventFlags::CGEventFlagCommand);
+                    if is_pressed {
+                        let was = pressed_clone.swap(true, Ordering::SeqCst);
+                        if !was {
+                            let n = pc.fetch_add(1, Ordering::SeqCst) + 1;
+                            info!(
+                                "[Hotkey] 事件 #press={} 按下（右侧 Command）was_pressed={} -> 发送",
+                                n, was
+                            );
+                            if let Err(e) = sender.send(HotkeyEvent::Pressed) {
+                                error!("发送热键事件失败: {}", e);
+                            }
+                        }
+                    } else {
+                        let was = pressed_clone.swap(false, Ordering::SeqCst);
+                        if was {
+                            let n = rc.fetch_add(1, Ordering::SeqCst) + 1;
+                            info!(
+                                "[Hotkey] 事件 #release={} 松开（右侧 Command）was_pressed={}",
+                                n, was
+                            );
+                            if let Err(e) = sender.send(HotkeyEvent::Released) {
+                                error!("发送热键事件失败: {}", e);
+                            }
+                        }
                     }
                 }
 
@@ -118,7 +159,7 @@ impl HotkeyListener {
     }
 
     #[cfg(not(target_os = "macos"))]
-    fn run_listen_loop_rdev(sender: Sender<HotkeyEvent>) -> Result<()> {
+    fn run_listen_loop_rdev(sender: Sender<HotkeyEvent>, _hotkey: &str) -> Result<()> {
         use rdev::{listen, Event, EventType, Key};
         use std::sync::atomic::{AtomicBool, AtomicU64};
 
@@ -133,25 +174,34 @@ impl HotkeyListener {
 
         // Windows / Linux: 右侧 Alt（AltGr）；与 macOS 右 Command 区分
         let result = listen(move |event: Event| {
-            let hotkey_press = matches!(event.event_type, EventType::KeyPress(Key::AltGr));
-            let hotkey_release = matches!(event.event_type, EventType::KeyRelease(Key::AltGr));
-            if hotkey_press {
-                let n = pc.fetch_add(1, Ordering::SeqCst) + 1;
-                let was = pressed_clone.swap(true, Ordering::SeqCst);
-                info!(
-                    "[Hotkey] 事件 #press={} 按下（右侧 Alt）was_pressed={} -> 发送",
-                    n, was
-                );
-                if let Err(e) = sender.send(HotkeyEvent) {
-                    error!("发送热键事件失败: {}", e);
+            match event.event_type {
+                EventType::KeyPress(Key::MetaRight) => {
+                    let was = pressed_clone.swap(true, Ordering::SeqCst);
+                    if !was {
+                        let n = pc.fetch_add(1, Ordering::SeqCst) + 1;
+                        info!(
+                            "[Hotkey] 事件 #press={} 按下",
+                            n
+                        );
+                        if let Err(e) = sender.send(HotkeyEvent::Pressed) {
+                            error!("发送热键事件失败: {}", e);
+                        }
+                    }
                 }
-            } else if hotkey_release {
-                let n = rc.fetch_add(1, Ordering::SeqCst) + 1;
-                let was = pressed_clone.swap(false, Ordering::SeqCst);
-                info!(
-                    "[Hotkey] 事件 #release={} 松开（右侧 Alt）was_pressed={}",
-                    n, was
-                );
+                EventType::KeyRelease(Key::MetaRight) => {
+                    let was = pressed_clone.swap(false, Ordering::SeqCst);
+                    if was {
+                        let n = rc.fetch_add(1, Ordering::SeqCst) + 1;
+                        info!(
+                            "[Hotkey] 事件 #release={} 松开",
+                            n
+                        );
+                        if let Err(e) = sender.send(HotkeyEvent::Released) {
+                            error!("发送热键事件失败: {}", e);
+                        }
+                    }
+                }
+                _ => {}
             }
         });
 
@@ -208,20 +258,61 @@ pub fn check_input_monitoring_permission() -> bool {
     }
 }
 
-/// 提示用户手动授予 Accessibility 权限（不主动弹系统框）
+/// 请求 Accessibility 权限——触发 macOS 系统对话框
 pub fn request_accessibility_permission() {
+    #[cfg(target_os = "macos")]
+    {
+        use core_foundation::base::TCFType;
+        use core_foundation::boolean::CFBoolean;
+        use core_foundation::dictionary::CFDictionary;
+        use core_foundation::string::CFString;
+
+        extern "C" {
+            fn AXIsProcessTrustedWithOptions(
+                options: core_foundation::dictionary::CFDictionaryRef,
+            ) -> bool;
+        }
+
+        // kAXTrustedCheckOptionPrompt = true → 触发系统权限对话框
+        let key = CFString::new("AXTrustedCheckOptionPrompt");
+        let val = CFBoolean::true_value();
+        let options = CFDictionary::from_CFType_pairs(&[(key.as_CFType(), val.as_CFType())]);
+        unsafe {
+            AXIsProcessTrustedWithOptions(options.as_concrete_TypeRef());
+        }
+    }
+
     warn!("需要 Accessibility 权限才能监听全局热键");
     println!("⚠️  需要 Accessibility 权限");
     println!("请前往：系统设置 > 隐私与安全性 > 辅助功能");
     println!("将 Open Flow.app 添加到列表并启用，然后完全退出后重新打开应用。");
 }
 
-/// 提示用户手动授予 Input Monitoring 权限（不主动弹系统框）
+/// 请求 Input Monitoring 权限——触发 macOS 系统对话框
 pub fn request_input_monitoring_permission() {
+    #[cfg(target_os = "macos")]
+    {
+        #[link(name = "ApplicationServices", kind = "framework")]
+        unsafe extern "C" {
+            fn CGRequestListenEventAccess() -> bool;
+        }
+
+        unsafe {
+            CGRequestListenEventAccess();
+        }
+    }
+
     warn!("需要 Input Monitoring 权限才能监听全局热键");
     println!("⚠️  需要“输入监控”权限");
     println!("请前往：系统设置 > 隐私与安全性 > 输入监控");
     println!("将 Open Flow.app 添加到列表并启用，然后完全退出后重新打开应用。");
+}
+
+/// 请求麦克风权限
+pub fn request_microphone_permission() {
+    info!("麦克风权限尚未授权。首次录音时将弹出系统对话框。");
+    println!("   首次录音时将弹出麦克风权限对话框。");
+    println!("   如果没有弹出，请前往：系统设置 > 隐私与安全性 > 麦克风");
 }
 
 /// 检查麦克风权限状态。

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,5 +4,6 @@ pub mod asr;
 pub mod audio;
 pub mod common;
 pub mod hotkey;
+pub mod overlay;
 pub mod text_injection;
 pub mod tray;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use open_flow::asr;
 use open_flow::audio;
 use open_flow::common;
 use open_flow::hotkey;
+use open_flow::overlay;
 use open_flow::text_injection;
 use open_flow::tray;
 

--- a/src/overlay/mod.rs
+++ b/src/overlay/mod.rs
@@ -1,0 +1,289 @@
+//! Floating indicator overlay: macOS uses native NSPanel near cursor,
+//! other platforms are no-op stubs.
+
+use crate::tray::TrayIconState;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// macOS implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "macos")]
+mod platform {
+    use super::*;
+    use cocoa::foundation::{NSPoint, NSRect, NSSize};
+    use objc::runtime::{Object, NO, YES};
+    use objc::{class, msg_send, sel, sel_impl};
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    const PILL_WIDTH: f64 = 140.0;
+    const PILL_HEIGHT: f64 = 28.0;
+    const CURSOR_OFFSET_Y: f64 = 20.0;
+
+    pub struct OverlayWindow {
+        panel: *mut Object,
+        text_field: *mut Object,
+        dot_view: *mut Object,
+        visible: AtomicBool,
+    }
+
+    unsafe impl Send for OverlayWindow {}
+    unsafe impl Sync for OverlayWindow {}
+
+    impl OverlayWindow {
+        pub fn new() -> Option<Self> {
+            unsafe {
+                let frame = NSRect::new(
+                    NSPoint::new(0.0, 0.0),
+                    NSSize::new(PILL_WIDTH, PILL_HEIGHT),
+                );
+
+                let style_mask: u64 = 0; // NSWindowStyleMaskBorderless
+                let panel: *mut Object = msg_send![class!(NSPanel), alloc];
+                let panel: *mut Object = msg_send![panel,
+                    initWithContentRect: frame
+                    styleMask: style_mask
+                    backing: 2u64 // NSBackingStoreBuffered
+                    defer: NO
+                ];
+
+                if panel.is_null() {
+                    return None;
+                }
+
+                // Configure panel
+                let _: () = msg_send![panel, setLevel: 25i64]; // NSStatusWindowLevel (above everything)
+                let _: () = msg_send![panel, setOpaque: NO];
+                let _: () = msg_send![panel, setHasShadow: NO];
+                let _: () = msg_send![panel, setIgnoresMouseEvents: YES];
+                // canJoinAllSpaces | stationary (visible on all spaces, doesn't move with space switch)
+                let _: () = msg_send![panel, setCollectionBehavior: (1u64 << 0) | (1u64 << 4)];
+                // Allow panel to show even when app is not active (critical for Accessory apps)
+                let _: () = msg_send![panel, setHidesOnDeactivate: NO];
+
+                // Set transparent background
+                let clear_color: *mut Object = msg_send![class!(NSColor), clearColor];
+                let _: () = msg_send![panel, setBackgroundColor: clear_color];
+
+                // Create content view with rounded dark background
+                let content_view: *mut Object = msg_send![panel, contentView];
+
+                // Create a visual effect view for blur
+                let effect_view: *mut Object = msg_send![class!(NSVisualEffectView), alloc];
+                let content_frame: NSRect = msg_send![content_view, bounds];
+                let effect_view: *mut Object =
+                    msg_send![effect_view, initWithFrame: content_frame];
+                let _: () = msg_send![effect_view, setMaterial: 13i64]; // HUDWindow
+                let _: () = msg_send![effect_view, setBlendingMode: 0i64]; // behindWindow
+                let _: () = msg_send![effect_view, setState: 1i64]; // active
+                let _: () = msg_send![effect_view, setWantsLayer: YES];
+
+                // Round corners
+                let layer: *mut Object = msg_send![effect_view, layer];
+                if !layer.is_null() {
+                    let _: () = msg_send![layer, setCornerRadius: (PILL_HEIGHT / 2.0) as f64];
+                    let _: () = msg_send![layer, setMasksToBounds: YES];
+                }
+
+                let _: () = msg_send![content_view, addSubview: effect_view];
+
+                // Red dot view (8x8, vertically centered)
+                let dot_size: f64 = 8.0;
+                let dot_frame = NSRect::new(
+                    NSPoint::new(10.0, (PILL_HEIGHT - dot_size) / 2.0),
+                    NSSize::new(dot_size, dot_size),
+                );
+                let dot_view: *mut Object = msg_send![class!(NSView), alloc];
+                let dot_view: *mut Object = msg_send![dot_view, initWithFrame: dot_frame];
+                let _: () = msg_send![dot_view, setWantsLayer: YES];
+                let dot_layer: *mut Object = msg_send![dot_view, layer];
+                if !dot_layer.is_null() {
+                    let _: () = msg_send![dot_layer, setCornerRadius: (dot_size / 2.0) as f64];
+                    let red: *mut Object = msg_send![class!(NSColor), redColor];
+                    let cg_red: *mut Object = msg_send![red, CGColor];
+                    let _: () = msg_send![dot_layer, setBackgroundColor: cg_red];
+                }
+                let _: () = msg_send![effect_view, addSubview: dot_view];
+
+                // Text label (vertically centered with proper line height)
+                let text_x: f64 = 24.0;
+                let text_h: f64 = 16.0;
+                let text_frame = NSRect::new(
+                    NSPoint::new(text_x, (PILL_HEIGHT - text_h) / 2.0),
+                    NSSize::new(PILL_WIDTH - text_x - 10.0, text_h),
+                );
+                let text_field: *mut Object = msg_send![class!(NSTextField), alloc];
+                let text_field: *mut Object = msg_send![text_field, initWithFrame: text_frame];
+                let _: () = msg_send![text_field, setBezeled: NO];
+                let _: () = msg_send![text_field, setDrawsBackground: NO];
+                let _: () = msg_send![text_field, setEditable: NO];
+                let _: () = msg_send![text_field, setSelectable: NO];
+
+                let white_alpha: *mut Object = msg_send![class!(NSColor),
+                    colorWithWhite: 1.0f64 alpha: 0.9f64];
+                let _: () = msg_send![text_field, setTextColor: white_alpha];
+
+                let font: *mut Object = msg_send![class!(NSFont), systemFontOfSize: 11.0f64];
+                let _: () = msg_send![text_field, setFont: font];
+
+                let ns_str = ns_string("Recording...");
+                let _: () = msg_send![text_field, setStringValue: ns_str];
+
+                let _: () = msg_send![effect_view, addSubview: text_field];
+
+                // Start hidden
+                let _: () = msg_send![panel, orderOut: std::ptr::null::<Object>()];
+
+                Some(Self {
+                    panel,
+                    text_field,
+                    dot_view,
+                    visible: AtomicBool::new(false),
+                })
+            }
+        }
+
+        pub fn update_state(&self, state: TrayIconState) {
+            unsafe {
+                match state {
+                    TrayIconState::Idle => {
+                        if self.visible.swap(false, Ordering::SeqCst) {
+                            let _: () =
+                                msg_send![self.panel, orderOut: std::ptr::null::<Object>()];
+                        }
+                    }
+                    TrayIconState::Recording => {
+                        // Position near cursor
+                        self.position_near_cursor();
+                        let ns_str = ns_string("Recording...");
+                        let _: () = msg_send![self.text_field, setStringValue: ns_str];
+                        // Red dot
+                        let dot_layer: *mut Object = msg_send![self.dot_view, layer];
+                        if !dot_layer.is_null() {
+                            let red: *mut Object = msg_send![class!(NSColor), redColor];
+                            let cg_red: *mut Object = msg_send![red, CGColor];
+                            let _: () = msg_send![dot_layer, setBackgroundColor: cg_red];
+                            // Start pulse animation
+                            Self::add_pulse_animation(dot_layer);
+                        }
+                        if !self.visible.swap(true, Ordering::SeqCst) {
+                            let _: () = msg_send![self.panel, orderFrontRegardless];
+                        }
+                    }
+                    TrayIconState::Transcribing => {
+                        let ns_str = ns_string("Transcribing...");
+                        let _: () = msg_send![self.text_field, setStringValue: ns_str];
+                        // Orange dot
+                        let dot_layer: *mut Object = msg_send![self.dot_view, layer];
+                        if !dot_layer.is_null() {
+                            let orange: *mut Object = msg_send![class!(NSColor), orangeColor];
+                            let cg_orange: *mut Object = msg_send![orange, CGColor];
+                            let _: () = msg_send![dot_layer, setBackgroundColor: cg_orange];
+                            // Remove pulse for transcribing state
+                            let key = ns_string("pulse");
+                            let _: () = msg_send![dot_layer, removeAnimationForKey: key];
+                        }
+                        if !self.visible.load(Ordering::SeqCst) {
+                            self.visible.store(true, Ordering::SeqCst);
+                            let _: () = msg_send![self.panel, orderFrontRegardless];
+                        }
+                    }
+                }
+            }
+        }
+
+        unsafe fn add_pulse_animation(layer: *mut Object) {
+            if layer.is_null() {
+                return;
+            }
+            let anim: *mut Object = msg_send![class!(CABasicAnimation),
+                animationWithKeyPath: ns_string("opacity")];
+            let from: *mut Object = msg_send![class!(NSNumber), numberWithFloat: 1.0f32];
+            let to: *mut Object = msg_send![class!(NSNumber), numberWithFloat: 0.3f32];
+            let _: () = msg_send![anim, setFromValue: from];
+            let _: () = msg_send![anim, setToValue: to];
+            let _: () = msg_send![anim, setDuration: 0.8f64];
+            let _: () = msg_send![anim, setAutoreverses: YES];
+            let _: () = msg_send![anim, setRepeatCount: f32::MAX];
+            let key = ns_string("pulse");
+            let _: () = msg_send![layer, addAnimation: anim forKey: key];
+        }
+
+        unsafe fn position_near_cursor(&self) {
+            // Get cursor position (screen coordinates, bottom-left origin)
+            let mouse_loc: NSPoint = msg_send![class!(NSEvent), mouseLocation];
+
+            // Find the screen containing the cursor
+            let screens: *mut Object = msg_send![class!(NSScreen), screens];
+            let screen_count: u64 = msg_send![screens, count];
+            let mut target_frame = NSRect::new(
+                NSPoint::new(0.0, 0.0),
+                NSSize::new(1920.0, 1080.0),
+            );
+
+            for i in 0..screen_count {
+                let screen: *mut Object = msg_send![screens, objectAtIndex: i];
+                let frame: NSRect = msg_send![screen, frame];
+                if mouse_loc.x >= frame.origin.x
+                    && mouse_loc.x <= frame.origin.x + frame.size.width
+                    && mouse_loc.y >= frame.origin.y
+                    && mouse_loc.y <= frame.origin.y + frame.size.height
+                {
+                    target_frame = frame;
+                    break;
+                }
+            }
+
+            // Position below cursor, centered, clamped to screen
+            let mut x = mouse_loc.x - PILL_WIDTH / 2.0;
+            let mut y = mouse_loc.y - PILL_HEIGHT - CURSOR_OFFSET_Y;
+
+            // Clamp to screen bounds
+            x = x
+                .max(target_frame.origin.x)
+                .min(target_frame.origin.x + target_frame.size.width - PILL_WIDTH);
+            y = y
+                .max(target_frame.origin.y)
+                .min(target_frame.origin.y + target_frame.size.height - PILL_HEIGHT);
+
+            let origin = NSPoint::new(x, y);
+            let _: () = msg_send![self.panel, setFrameOrigin: origin];
+        }
+    }
+
+    impl Drop for OverlayWindow {
+        fn drop(&mut self) {
+            unsafe {
+                let _: () = msg_send![self.panel, orderOut: std::ptr::null::<Object>()];
+                let _: () = msg_send![self.panel, close];
+            }
+        }
+    }
+
+    /// Create an NSString from a Rust &str (null-terminated for ObjC).
+    unsafe fn ns_string(s: &str) -> *mut Object {
+        let cls = class!(NSString);
+        let c_str = std::ffi::CString::new(s).unwrap();
+        msg_send![cls, stringWithUTF8String: c_str.as_ptr()]
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Non-macOS stub
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(not(target_os = "macos"))]
+mod platform {
+    use super::*;
+
+    pub struct OverlayWindow;
+
+    impl OverlayWindow {
+        pub fn new() -> Option<Self> {
+            Some(Self)
+        }
+
+        pub fn update_state(&self, _state: TrayIconState) {}
+    }
+}
+
+pub use platform::OverlayWindow;

--- a/src/text_injection/chinese_convert.rs
+++ b/src/text_injection/chinese_convert.rs
@@ -1,0 +1,107 @@
+/// Convert between simplified and traditional Chinese using macOS native APIs.
+/// Falls back to no-op on non-macOS platforms.
+
+/// Apply Chinese character conversion based on config value.
+/// - "s2t": Simplified -> Traditional
+/// - "t2s": Traditional -> Simplified
+/// - "" or "none": no conversion
+pub fn convert_chinese(text: &str, mode: &str) -> String {
+    match mode {
+        "s2t" => transform_string(text, false),
+        "t2s" => transform_string(text, true),
+        _ => text.to_string(),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn transform_string(text: &str, reverse: bool) -> String {
+    use core_foundation::base::TCFType;
+    use core_foundation::string::CFString;
+
+    // CFStringTransform with "Simplified-Traditional"
+    // reverse=false: Simplified -> Traditional
+    // reverse=true:  Traditional -> Simplified
+    extern "C" {
+        fn CFStringCreateMutableCopy(
+            alloc: *const std::ffi::c_void,
+            max_length: i64,
+            the_string: core_foundation::string::CFStringRef,
+        ) -> *mut std::ffi::c_void;
+
+        fn CFStringTransform(
+            string: *mut std::ffi::c_void,
+            range: *mut std::ffi::c_void,
+            transform: core_foundation::string::CFStringRef,
+            reverse: bool,
+        ) -> bool;
+    }
+
+    let cf_text = CFString::new(text);
+    let transform = CFString::new("Simplified-Traditional");
+
+    unsafe {
+        let mutable = CFStringCreateMutableCopy(
+            std::ptr::null(),
+            0,
+            cf_text.as_concrete_TypeRef(),
+        );
+        if mutable.is_null() {
+            return text.to_string();
+        }
+
+        let ok = CFStringTransform(
+            mutable,
+            std::ptr::null_mut(),
+            transform.as_concrete_TypeRef(),
+            reverse,
+        );
+
+        if ok {
+            // Read back the transformed string
+            let cf_result = CFString::wrap_under_create_rule(mutable as core_foundation::string::CFStringRef);
+            cf_result.to_string()
+        } else {
+            // Transform failed, return original
+            core_foundation::base::CFRelease(mutable);
+            text.to_string()
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn transform_string(text: &str, _reverse: bool) -> String {
+    text.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_no_conversion() {
+        assert_eq!(convert_chinese("hello", ""), "hello");
+        assert_eq!(convert_chinese("hello", "none"), "hello");
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_s2t() {
+        let result = convert_chinese("简体中文测试", "s2t");
+        assert!(
+            result.contains('簡') || result.contains('體'),
+            "Expected traditional chars, got: {}",
+            result
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_t2s() {
+        let result = convert_chinese("簡體中文測試", "t2s");
+        assert!(
+            result.contains('简') || result.contains('体'),
+            "Expected simplified chars, got: {}",
+            result
+        );
+    }
+}

--- a/src/text_injection/mod.rs
+++ b/src/text_injection/mod.rs
@@ -1,42 +1,104 @@
-use anyhow::{Context, Result};
+pub mod chinese_convert;
+
+use anyhow::Result;
 use std::time::Duration;
 
-/// 文本注入器：剪贴板 + 模拟粘贴快捷键
-pub struct TextInjector;
+/// 文本注入器：可选的中文转换 + 通过 CGEvent 模拟打字（macOS）
+/// 或剪贴板粘贴回退（其他平台）
+pub struct TextInjector {
+    chinese_conversion: String,
+}
 
 impl TextInjector {
     pub fn new() -> Self {
-        Self
+        let config = crate::common::config::Config::load().unwrap_or_default();
+        Self {
+            chinese_conversion: config.chinese_conversion,
+        }
     }
 
     pub async fn inject(&self, text: &str) -> Result<()> {
-        use arboard::Clipboard;
+        // 1. 如果配置了中文转换则应用
+        let text = chinese_convert::convert_chinese(text, &self.chinese_conversion);
 
-        // 1. 写入剪贴板
-        let mut clipboard = Clipboard::new().context("无法访问剪贴板")?;
-        clipboard.set_text(text).context("写入剪贴板失败")?;
+        // 2. 同时写入剪贴板作为备份
+        if let Ok(mut clipboard) = arboard::Clipboard::new() {
+            let _ = clipboard.set_text(&text);
+        }
 
-        tokio::time::sleep(Duration::from_millis(60)).await;
-
-        // 2. 模拟粘贴（平台分支）
-        Self::paste_from_clipboard(text).await
+        // 3. 输入文本（平台特定）
+        Self::type_text(&text).await
     }
 
+    /// macOS: 使用 CGEvent 键盘事件模拟真实打字。
+    /// 比剪贴板粘贴 (Cmd+V) 在不同应用中更一致。
     #[cfg(target_os = "macos")]
-    async fn paste_from_clipboard(_text: &str) -> Result<()> {
-        // osascript 走 Accessibility API（不经过 CGEventTap，避免修饰键竞争）
-        std::process::Command::new("osascript")
-            .arg("-e")
-            .arg(r#"tell application "System Events" to keystroke "v" using {command down}"#)
-            .output()
-            .context("osascript 执行失败")?;
+    async fn type_text(text: &str) -> Result<()> {
+        use std::ffi::c_void;
+
+        #[link(name = "ApplicationServices", kind = "framework")]
+        extern "C" {
+            fn CGEventCreateKeyboardEvent(
+                source: *const c_void,
+                virtual_key: u16,
+                key_down: bool,
+            ) -> *mut c_void;
+            fn CGEventKeyboardSetUnicodeString(
+                event: *mut c_void,
+                string_length: usize,
+                unicode_string: *const u16,
+            );
+            fn CGEventPost(tap: u32, event: *mut c_void);
+            fn CFRelease(cf: *const c_void);
+        }
+
+        fn post_unicode_chunk(chunk: &[u16]) {
+            unsafe {
+                // Key down
+                let down = CGEventCreateKeyboardEvent(std::ptr::null(), 0, true);
+                if down.is_null() {
+                    return;
+                }
+                CGEventKeyboardSetUnicodeString(down, chunk.len(), chunk.as_ptr());
+                CGEventPost(0, down); // 0 = kCGHIDEventTap
+                CFRelease(down);
+
+                // Key up
+                let up = CGEventCreateKeyboardEvent(std::ptr::null(), 0, false);
+                if up.is_null() {
+                    return;
+                }
+                CGEventKeyboardSetUnicodeString(up, chunk.len(), chunk.as_ptr());
+                CGEventPost(0, up);
+                CFRelease(up);
+            }
+        }
+
+        if text.is_empty() {
+            return Ok(());
+        }
+
+        // Normalize newlines for terminal compatibility
+        let normalized = text.replace('\n', "\r");
+        let utf16: Vec<u16> = normalized.encode_utf16().collect();
+
+        // Post in small chunks with a short delay between each for consistency
+        const CHUNK_SIZE: usize = 20;
+        const CHUNK_DELAY_MS: u64 = 5;
+
+        for chunk in utf16.chunks(CHUNK_SIZE) {
+            post_unicode_chunk(chunk);
+            if CHUNK_DELAY_MS > 0 {
+                tokio::time::sleep(Duration::from_millis(CHUNK_DELAY_MS)).await;
+            }
+        }
+
         Ok(())
     }
 
     #[cfg(target_os = "linux")]
-    async fn paste_from_clipboard(_text: &str) -> Result<()> {
+    async fn type_text(_text: &str) -> Result<()> {
         // 优先尝试 xdotool（X11 / XWayland），其次 wl-paste+wtype（纯 Wayland）
-        // xdotool key --clearmodifiers ctrl+v
         let xdotool = std::process::Command::new("xdotool")
             .args(["key", "--clearmodifiers", "ctrl+v"])
             .output();
@@ -81,7 +143,7 @@ impl TextInjector {
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-    async fn paste_from_clipboard(_text: &str) -> Result<()> {
+    async fn type_text(_text: &str) -> Result<()> {
         tracing::warn!("当前平台不支持自动粘贴，转写结果已写入剪贴板，请手动粘贴（Ctrl+V / Cmd+V）。");
         Ok(())
     }

--- a/src/tray/mod.rs
+++ b/src/tray/mod.rs
@@ -27,15 +27,22 @@ mod platform {
     /// Send+Sync 句柄，供 daemon 背景线程使用
     pub struct TrayHandle {
         pub(super) state_tx: std::sync::mpsc::SyncSender<TrayIconState>,
+        pub(super) overlay_state_tx: Option<std::sync::mpsc::SyncSender<TrayIconState>>,
         pub(super) exit_requested: Arc<AtomicBool>,
     }
 
     impl TrayHandle {
         pub fn set_state(&self, state: TrayIconState) {
             let _ = self.state_tx.try_send(state);
+            if let Some(ref tx) = self.overlay_state_tx {
+                let _ = tx.try_send(state);
+            }
         }
         pub fn exit_requested(&self) -> bool {
             self.exit_requested.load(Ordering::SeqCst)
+        }
+        pub fn set_overlay_sender(&mut self, tx: std::sync::mpsc::SyncSender<TrayIconState>) {
+            self.overlay_state_tx = Some(tx);
         }
     }
 
@@ -47,6 +54,7 @@ mod platform {
         icon_transcribing: Icon,
         status_item: MenuItem,
         pub exit_requested: Arc<AtomicBool>,
+        pub prefs_requested: Arc<AtomicBool>,
         state_rx: std::sync::mpsc::Receiver<TrayIconState>,
     }
 
@@ -57,13 +65,15 @@ mod platform {
             let icon_transcribing = create_circle_icon(255, 200, 0);
 
             let exit_requested = Arc::new(AtomicBool::new(false));
+            let prefs_requested = Arc::new(AtomicBool::new(false));
             let (state_tx, state_rx) = std::sync::mpsc::sync_channel::<TrayIconState>(16);
 
             let title = MenuItem::with_id("title", format!("Open Flow  v{}", env!("CARGO_PKG_VERSION")), true, None);
             let status_item = MenuItem::with_id("status", "状态：待机", false, None);
+            let prefs = MenuItem::with_id("prefs", "偏好设置...", true, None);
             let exit = MenuItem::with_id("exit", "退出", true, None);
 
-            let menu = Menu::with_items(&[&title, &status_item, &exit])
+            let menu = Menu::with_items(&[&title, &status_item, &prefs, &exit])
                 .map_err(|e| tray_icon::Error::OsError(std::io::Error::new(std::io::ErrorKind::Other, e.to_string())))?;
 
             let tray_icon = TrayIconBuilder::new()
@@ -72,10 +82,10 @@ mod platform {
                 .with_icon(icon_idle.clone())
                 .build()?;
 
-            let handle = TrayHandle { state_tx, exit_requested: exit_requested.clone() };
+            let handle = TrayHandle { state_tx, overlay_state_tx: None, exit_requested: exit_requested.clone() };
             let tray_state = Self {
                 tray_icon, icon_idle, icon_recording, icon_transcribing,
-                status_item, exit_requested, state_rx,
+                status_item, exit_requested, prefs_requested, state_rx,
             };
             Ok((tray_state, handle))
         }
@@ -95,6 +105,9 @@ mod platform {
                 if event.id.as_ref() == "exit" {
                     info!("用户点击退出菜单");
                     self.exit_requested.store(true, Ordering::SeqCst);
+                } else if event.id.as_ref() == "prefs" {
+                    info!("用户点击偏好设置菜单");
+                    self.prefs_requested.store(true, Ordering::SeqCst);
                 } else if event.id.as_ref() == "title" {
                     let _ = std::process::Command::new("open")
                         .arg("https://github.com/jqlong17/open-flow")
@@ -117,6 +130,10 @@ mod platform {
 
         pub fn exit_requested(&self) -> bool {
             self.exit_requested.load(Ordering::SeqCst)
+        }
+
+        pub fn prefs_requested(&self) -> bool {
+            self.prefs_requested.swap(false, Ordering::SeqCst)
         }
 
         pub fn hide_from_menu_bar(&self) {
@@ -150,288 +167,10 @@ mod platform {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Windows：系统托盘（任务栏右侧），三态图标 + 菜单，需主线程跑 Win32 消息循环
+// 非 macOS：无操作 stub（可编译，运行时无副作用）
 // ─────────────────────────────────────────────────────────────────────────────
 
-#[cfg(target_os = "windows")]
-mod platform {
-    use super::TrayIconState;
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::Arc;
-    use tray_icon::menu::{Menu, MenuEvent, MenuItem};
-    use tray_icon::{Icon, TrayIconBuilder};
-    use tracing::info;
-
-    const ICON_SIZE: u32 = 22;
-    const DOT_RADIUS: f32 = 4.0;
-
-    pub struct TrayHandle {
-        pub(super) state_tx: std::sync::mpsc::SyncSender<TrayIconState>,
-        pub(super) exit_requested: Arc<AtomicBool>,
-    }
-
-    impl TrayHandle {
-        pub fn set_state(&self, state: TrayIconState) {
-            let _ = self.state_tx.try_send(state);
-        }
-        pub fn exit_requested(&self) -> bool {
-            self.exit_requested.load(Ordering::SeqCst)
-        }
-    }
-
-    pub struct TrayState {
-        tray_icon: tray_icon::TrayIcon,
-        icon_idle: Icon,
-        icon_recording: Icon,
-        icon_transcribing: Icon,
-        status_item: MenuItem,
-        pub exit_requested: Arc<AtomicBool>,
-        state_rx: std::sync::mpsc::Receiver<TrayIconState>,
-    }
-
-    impl TrayState {
-        pub fn new() -> Result<(Self, TrayHandle), tray_icon::Error> {
-            let icon_idle = create_circle_icon(128, 128, 128);
-            let icon_recording = create_circle_icon(255, 80, 80);
-            let icon_transcribing = create_circle_icon(255, 200, 0);
-
-            let exit_requested = Arc::new(AtomicBool::new(false));
-            let (state_tx, state_rx) = std::sync::mpsc::sync_channel::<TrayIconState>(16);
-
-            let title = MenuItem::with_id("title", format!("Open Flow  v{}", env!("CARGO_PKG_VERSION")), true, None);
-            let status_item = MenuItem::with_id("status", "状态：待机", false, None);
-            let exit = MenuItem::with_id("exit", "退出", true, None);
-
-            let menu = Menu::with_items(&[&title, &status_item, &exit])
-                .map_err(|e| tray_icon::Error::OsError(std::io::Error::new(std::io::ErrorKind::Other, e.to_string())))?;
-
-            let tray_icon = TrayIconBuilder::new()
-                .with_menu(Box::new(menu))
-                .with_tooltip("Open Flow - 语音输入")
-                .with_icon(icon_idle.clone())
-                .build()?;
-
-            let handle = TrayHandle { state_tx, exit_requested: exit_requested.clone() };
-            let tray_state = Self {
-                tray_icon, icon_idle, icon_recording, icon_transcribing,
-                status_item, exit_requested, state_rx,
-            };
-            Ok((tray_state, handle))
-        }
-
-        pub fn set_state(&self, state: TrayIconState) {
-            self.apply_state(state);
-        }
-
-        pub fn flush_state_updates(&self) {
-            while let Ok(state) = self.state_rx.try_recv() {
-                self.apply_state(state);
-            }
-        }
-
-        pub fn flush_menu_events(&self) {
-            while let Ok(event) = MenuEvent::receiver().try_recv() {
-                if event.id.as_ref() == "exit" {
-                    info!("用户点击退出菜单");
-                    self.exit_requested.store(true, Ordering::SeqCst);
-                } else if event.id.as_ref() == "title" {
-                    let _ = std::process::Command::new("cmd")
-                        .args(["/C", "start", "", "https://github.com/jqlong17/open-flow"])
-                        .spawn();
-                }
-            }
-        }
-
-        fn apply_state(&self, state: TrayIconState) {
-            let (icon, text) = match state {
-                TrayIconState::Idle => (&self.icon_idle, "状态：待机"),
-                TrayIconState::Recording => (&self.icon_recording, "状态：录音中"),
-                TrayIconState::Transcribing => (&self.icon_transcribing, "状态：转写中"),
-            };
-            if let Err(e) = self.tray_icon.set_icon(Some(icon.clone())) {
-                tracing::warn!("更新托盘图标失败: {:?}", e);
-            }
-            self.status_item.set_text(text);
-        }
-
-        pub fn exit_requested(&self) -> bool {
-            self.exit_requested.load(Ordering::SeqCst)
-        }
-
-        pub fn hide_from_menu_bar(&self) {
-            if let Err(e) = self.tray_icon.set_visible(false) {
-                tracing::warn!("隐藏托盘图标失败: {:?}", e);
-            }
-        }
-    }
-
-    fn create_circle_icon(r: u8, g: u8, b: u8) -> Icon {
-        let size = ICON_SIZE as usize;
-        let center = size as f32 / 2.0 - 0.5;
-        let mut rgba = vec![0u8; size * size * 4];
-        for y in 0..size {
-            for x in 0..size {
-                let dx = x as f32 - center;
-                let dy = y as f32 - center;
-                let dist = (dx * dx + dy * dy).sqrt();
-                let idx = (y * size + x) * 4;
-                let alpha = ((DOT_RADIUS + 0.5 - dist).clamp(0.0, 1.0) * 255.0) as u8;
-                if alpha > 0 {
-                    rgba[idx] = r;
-                    rgba[idx + 1] = g;
-                    rgba[idx + 2] = b;
-                    rgba[idx + 3] = alpha;
-                }
-            }
-        }
-        Icon::from_rgba(rgba, ICON_SIZE, ICON_SIZE).expect("icon")
-    }
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Linux：系统托盘（通知区域），三态图标 + 菜单，需主线程跑 glib 事件循环
-// ─────────────────────────────────────────────────────────────────────────────
-
-#[cfg(target_os = "linux")]
-mod platform {
-    use super::TrayIconState;
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::Arc;
-    use tray_icon::menu::{Menu, MenuEvent, MenuItem};
-    use tray_icon::{Icon, TrayIconBuilder};
-    use tracing::info;
-
-    const ICON_SIZE: u32 = 22;
-    const DOT_RADIUS: f32 = 4.0;
-
-    pub struct TrayHandle {
-        pub(super) state_tx: std::sync::mpsc::SyncSender<TrayIconState>,
-        pub(super) exit_requested: Arc<AtomicBool>,
-    }
-
-    impl TrayHandle {
-        pub fn set_state(&self, state: TrayIconState) {
-            let _ = self.state_tx.try_send(state);
-        }
-        pub fn exit_requested(&self) -> bool {
-            self.exit_requested.load(Ordering::SeqCst)
-        }
-    }
-
-    pub struct TrayState {
-        tray_icon: tray_icon::TrayIcon,
-        icon_idle: Icon,
-        icon_recording: Icon,
-        icon_transcribing: Icon,
-        status_item: MenuItem,
-        pub exit_requested: Arc<AtomicBool>,
-        state_rx: std::sync::mpsc::Receiver<TrayIconState>,
-    }
-
-    impl TrayState {
-        pub fn new() -> Result<(Self, TrayHandle), tray_icon::Error> {
-            let icon_idle = create_circle_icon(128, 128, 128);
-            let icon_recording = create_circle_icon(255, 80, 80);
-            let icon_transcribing = create_circle_icon(255, 200, 0);
-
-            let exit_requested = Arc::new(AtomicBool::new(false));
-            let (state_tx, state_rx) = std::sync::mpsc::sync_channel::<TrayIconState>(16);
-
-            let title = MenuItem::with_id("title", format!("Open Flow  v{}", env!("CARGO_PKG_VERSION")), true, None);
-            let status_item = MenuItem::with_id("status", "状态：待机", false, None);
-            let exit = MenuItem::with_id("exit", "退出", true, None);
-
-            let menu = Menu::with_items(&[&title, &status_item, &exit])
-                .map_err(|e| tray_icon::Error::OsError(std::io::Error::new(std::io::ErrorKind::Other, e.to_string())))?;
-
-            let tray_icon = TrayIconBuilder::new()
-                .with_menu(Box::new(menu))
-                .with_tooltip("Open Flow - 语音输入")
-                .with_icon(icon_idle.clone())
-                .build()?;
-
-            let handle = TrayHandle { state_tx, exit_requested: exit_requested.clone() };
-            let tray_state = Self {
-                tray_icon, icon_idle, icon_recording, icon_transcribing,
-                status_item, exit_requested, state_rx,
-            };
-            Ok((tray_state, handle))
-        }
-
-        pub fn set_state(&self, state: TrayIconState) {
-            self.apply_state(state);
-        }
-
-        pub fn flush_state_updates(&self) {
-            while let Ok(state) = self.state_rx.try_recv() {
-                self.apply_state(state);
-            }
-        }
-
-        pub fn flush_menu_events(&self) {
-            while let Ok(event) = MenuEvent::receiver().try_recv() {
-                if event.id.as_ref() == "exit" {
-                    info!("用户点击退出菜单");
-                    self.exit_requested.store(true, Ordering::SeqCst);
-                } else if event.id.as_ref() == "title" {
-                    let _ = std::process::Command::new("xdg-open")
-                        .arg("https://github.com/jqlong17/open-flow")
-                        .spawn();
-                }
-            }
-        }
-
-        fn apply_state(&self, state: TrayIconState) {
-            let (icon, text) = match state {
-                TrayIconState::Idle => (&self.icon_idle, "状态：待机"),
-                TrayIconState::Recording => (&self.icon_recording, "状态：录音中"),
-                TrayIconState::Transcribing => (&self.icon_transcribing, "状态：转写中"),
-            };
-            if let Err(e) = self.tray_icon.set_icon(Some(icon.clone())) {
-                tracing::warn!("更新托盘图标失败: {:?}", e);
-            }
-            self.status_item.set_text(text);
-        }
-
-        pub fn exit_requested(&self) -> bool {
-            self.exit_requested.load(Ordering::SeqCst)
-        }
-
-        pub fn hide_from_menu_bar(&self) {
-            if let Err(e) = self.tray_icon.set_visible(false) {
-                tracing::warn!("隐藏托盘图标失败: {:?}", e);
-            }
-        }
-    }
-
-    fn create_circle_icon(r: u8, g: u8, b: u8) -> Icon {
-        let size = ICON_SIZE as usize;
-        let center = size as f32 / 2.0 - 0.5;
-        let mut rgba = vec![0u8; size * size * 4];
-        for y in 0..size {
-            for x in 0..size {
-                let dx = x as f32 - center;
-                let dy = y as f32 - center;
-                let dist = (dx * dx + dy * dy).sqrt();
-                let idx = (y * size + x) * 4;
-                let alpha = ((DOT_RADIUS + 0.5 - dist).clamp(0.0, 1.0) * 255.0) as u8;
-                if alpha > 0 {
-                    rgba[idx] = r;
-                    rgba[idx + 1] = g;
-                    rgba[idx + 2] = b;
-                    rgba[idx + 3] = alpha;
-                }
-            }
-        }
-        Icon::from_rgba(rgba, ICON_SIZE, ICON_SIZE).expect("icon")
-    }
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// 非 macOS / Windows / Linux：无操作 stub
-// ─────────────────────────────────────────────────────────────────────────────
-
-#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+#[cfg(not(target_os = "macos"))]
 mod platform {
     use super::TrayIconState;
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -446,6 +185,7 @@ mod platform {
         pub fn exit_requested(&self) -> bool {
             self.exit_requested.load(Ordering::SeqCst)
         }
+        pub fn set_overlay_sender(&mut self, _tx: std::sync::mpsc::SyncSender<TrayIconState>) {}
     }
 
     pub struct TrayState {
@@ -453,7 +193,7 @@ mod platform {
     }
 
     impl TrayState {
-        pub fn new() -> Result<(Self, TrayHandle), tray_icon::Error> {
+        pub fn new() -> Result<(Self, TrayHandle), std::io::Error> {
             let flag = Arc::new(AtomicBool::new(false));
             Ok((
                 Self { exit_requested: flag.clone() },
@@ -465,6 +205,9 @@ mod platform {
         pub fn flush_menu_events(&self) {}
         pub fn exit_requested(&self) -> bool {
             self.exit_requested.load(Ordering::SeqCst)
+        }
+        pub fn prefs_requested(&self) -> bool {
+            false
         }
         pub fn hide_from_menu_bar(&self) {}
     }


### PR DESCRIPTION
## 概述

新增近游標浮動錄音指示器（macOS 原生 NSPanel）、真實打字注入（取代剪貼板貼上）、以及簡體/繁體中文自動轉換。

> 依賴 PR #2（Groq + 熱鍵）

## 主要變更

### 浮動指示器（Overlay）
<img width="330" height="136" alt="CleanShot 2026-03-15 at 02 45 56@2x" src="https://github.com/user-attachments/assets/ab3d3ae5-ea99-400e-946e-0dfb744d9032" />

- 使用 macOS 原生 `NSPanel`，錄音時在游標附近顯示藥丸形狀指示器
- `NSVisualEffectView` HUD 材質模糊背景
- 錄音時：紅色脈動圓點 + "录音中..."
- 轉寫時：橘色圓點 + "转写中..."
- `setIgnoresMouseEvents: YES`（滑鼠穿透）
- `setHidesOnDeactivate: NO`（Accessory policy 應用也能顯示）
- 自動定位到游標所在螢幕，不超出螢幕邊界

### CGEvent 打字注入
- 使用 `CGEventCreateKeyboardEvent` + `CGEventKeyboardSetUnicodeString` 模擬真實打字
- 每 20 個 UTF-16 字元為一組，間隔 5ms，跨應用表現一致
- 換行符轉換為 `\r`，相容終端機
- 轉寫結果同時寫入剪貼板作為備份

### 簡繁轉換
- 使用 macOS 原生 `CFStringTransform("Simplified-Traditional")` 
- config.toml 新增 `chinese_conversion` 欄位：`s2t`（簡→繁）/ `t2s`（繁→簡）/ 留空不轉換
- 在文字注入前自動套用

### 托盤選單更新
- 新增「偏好设置...」選單項目
- Overlay 狀態透過獨立 channel 從 daemon 同步到主線程

## 平台支援
- macOS：完整實作
- Linux / Windows：stub（無 overlay，維持剪貼板貼上）

## 測試計畫

- [x] `cargo check` 通過
- [x] `cargo test` 全部通過（含 3 個新的簡繁轉換測試）
- [x] 測試浮動指示器在錄音/轉寫時正確顯示
- [x] 測試 CGEvent 打字在不同應用中的表現（編輯器、終端、瀏覽器）
- [ ] 測試簡繁轉換功能